### PR TITLE
Fixed command line arguments parsing bug

### DIFF
--- a/driver/src/main/scala/za/co/absa/hyperdrive/driver/drivers/CommandLineIngestionDriver.scala
+++ b/driver/src/main/scala/za/co/absa/hyperdrive/driver/drivers/CommandLineIngestionDriver.scala
@@ -44,8 +44,8 @@ object CommandLineIngestionDriver extends IngestionDriver {
   }
 
   private def setOrThrow(setting: String, configuration: Configuration): Unit = {
-    val settingKeyValue = setting.trim.split("=")
-    if (settingKeyValue.length != 2) {
+    val settingKeyValue = setting.trim.split("=", 2)
+    if (settingKeyValue.length != 2 || settingKeyValue.exists(_.isEmpty)) {
       throw new IllegalArgumentException(s"Invalid setting format: $setting")
     }
     configuration.setProperty(settingKeyValue(0), settingKeyValue(1))

--- a/driver/src/test/scala/za/co/absa/hyperdrive/driver/drivers/TestCommandLineIngestionDriver.scala
+++ b/driver/src/test/scala/za/co/absa/hyperdrive/driver/drivers/TestCommandLineIngestionDriver.scala
@@ -52,7 +52,8 @@ class TestCommandLineIngestionDriver extends FlatSpec {
       KEY_KEYSTORE_PASSWORD -> "any-keystore!!@#$% password",
       KEY_KEYSTORE_LOCATION -> "/tmp/wherever/keystore.jks",
       KEY_TRUSTSTORE_PASSWORD -> "kd9910))383(((*-+",
-      KEY_TRUSTSTORE_LOCATION -> "another/place/truststore.jks"
+      KEY_TRUSTSTORE_LOCATION -> "another/place/truststore.jks",
+      "key.equals.sign.in.value" -> "value1=value2"
     )
   }
 }


### PR DESCRIPTION
Fixed command line arguments parsing bug = value can contain equals sign.