### PR TITLE
Adding Parquet stream writer that sets all columns to nullable.

### DIFF
--- a/driver/src/main/resources/Ingestion.properties.template
+++ b/driver/src/main/resources/Ingestion.properties.template
@@ -23,7 +23,7 @@ component.reader=za.co.absa.hyperdrive.ingestor.implementation.reader.kafka.Kafk
 component.decoder=za.co.absa.hyperdrive.ingestor.implementation.decoder.avro.confluent.ConfluentAvroKafkaStreamDecoder
 component.manager=za.co.absa.hyperdrive.ingestor.implementation.manager.checkpoint.CheckpointOffsetManager
 component.transformer=za.co.absa.hyperdrive.ingestor.implementation.transformer.column.selection.ColumnSelectorStreamTransformer
-component.writer=za.co.absa.hyperdrive.ingestor.implementation.writer.parquet.ParquetStreamWriter
+component.writer=za.co.absa.hyperdrive.ingestor.implementation.writer.parquet.AllNullableParquetStreamWriter
 
 # Spark settings
 ingestor.spark.app.name=ingestor-app-pane

--- a/ingestor/ingestor-default/pom.xml
+++ b/ingestor/ingestor-default/pom.xml
@@ -13,12 +13,12 @@
     <artifactId>ingestor-default</artifactId>
 
     <dependencies>
+        <!--Hyperdrive-->
         <dependency>
             <groupId>za.co.absa.hyperdrive</groupId>
             <artifactId>api</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>za.co.absa.hyperdrive</groupId>
             <artifactId>shared</artifactId>

--- a/ingestor/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/AllNullableParquetStreamWriter.scala
+++ b/ingestor/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/AllNullableParquetStreamWriter.scala
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2019 ABSA Group Limited
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.ingestor.implementation.writer.parquet
+
+import org.apache.commons.configuration2.Configuration
+import org.apache.logging.log4j.LogManager
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.streaming.StreamingQuery
+import za.co.absa.hyperdrive.ingestor.api.manager.OffsetManager
+import za.co.absa.hyperdrive.ingestor.api.writer.{StreamWriter, StreamWriterFactory}
+import za.co.absa.hyperdrive.shared.utils.SparkUtils
+
+/**
+  * Works as a decorator for [[ParquetStreamWriter]] by setting the nullability of all fields of the
+  * incoming DataFrame to null.
+  */
+private[parquet] class AllNullableParquetStreamWriter(val parquetStreamWriter: StreamWriter)
+  extends StreamWriter(parquetStreamWriter.getDestination) {
+
+  override def getDestination: String = parquetStreamWriter.getDestination
+
+  override def write(dataFrame: DataFrame, offsetManager: OffsetManager): StreamingQuery = {
+    val allNullableDataFrame = SparkUtils.setAllColumnsNullable(dataFrame)
+    parquetStreamWriter.write(allNullableDataFrame, offsetManager)
+  }
+}
+
+/**
+  * Reuses factory for [[ParquetStreamWriter]].
+  */
+object AllNullableParquetStreamWriter extends StreamWriterFactory {
+
+  override def apply(config: Configuration): StreamWriter = {
+    LogManager.getLogger.info(s"Going to create ${classOf[AllNullableParquetStreamWriter].getSimpleName} instance. Injecting ${classOf[ParquetStreamWriter].getSimpleName} instance.")
+    val parquetWriter = ParquetStreamWriter(config)
+    new AllNullableParquetStreamWriter(parquetWriter)
+  }
+}

--- a/ingestor/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/TestAllNullableParquetStreamWriter.scala
+++ b/ingestor/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/TestAllNullableParquetStreamWriter.scala
@@ -1,0 +1,73 @@
+/*
+ *  Copyright 2019 ABSA Group Limited
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.ingestor.implementation.writer.parquet
+
+import org.apache.spark.sql.streaming.StreamingQuery
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.types._
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfterEach, FunSuite}
+import za.co.absa.hyperdrive.ingestor.api.manager.OffsetManager
+import za.co.absa.hyperdrive.ingestor.api.writer.StreamWriter
+import za.co.absa.hyperdrive.shared.test.utils.SparkTestUtils._
+
+class TestAllNullableParquetStreamWriter extends FunSuite with BeforeAndAfterEach with MockitoSugar {
+
+  private object dummyStreamWriter extends StreamWriter("/tmp/any") {
+    override def getDestination: String = "/tmp/any"
+
+    var capturedDataframe: DataFrame = _
+    var capturedOffsetManager: OffsetManager = _
+
+    override def write(dataFrame: DataFrame, offsetManager: OffsetManager): StreamingQuery = {
+      capturedDataframe = dataFrame
+      capturedOffsetManager = offsetManager
+      null
+    }
+  }
+
+  private val spark = SparkSession.builder().appName(classOf[TestAllNullableParquetStreamWriter].getSimpleName).master("local").getOrCreate()
+  spark.sparkContext.setLogLevel("ERROR")
+
+  private val stubOffsetManager = mock[OffsetManager]
+  private val fakeDataFrame = getTestDataframe
+
+  test(testName = "Dataframe has all columns nullabilities set to true before being passed to injected writer") {
+    assert(!areAllFieldsNullable(fakeDataFrame.schema))
+
+    val writer = new AllNullableParquetStreamWriter(dummyStreamWriter)
+    writer.write(fakeDataFrame, stubOffsetManager)
+
+    assert(dummyStreamWriter.capturedOffsetManager == stubOffsetManager)
+    assert(areAllFieldsNullable(dummyStreamWriter.capturedDataframe.schema))
+  }
+
+  private def getTestDataframe: DataFrame = {
+    val nestedType1 = new StructType()
+      .add(StructField("a", IntegerType, false))
+      .add(StructField("b", LongType, false))
+
+    val nestedType2 = new StructType()
+      .add(StructField("c", ArrayType(nestedType1, false), false))
+
+    val schema = new StructType()
+      .add(StructField("d", StringType, false))
+      .add(StructField("e", ArrayType(nestedType2, false), false))
+
+    spark.createDataFrame(spark.emptyDataFrame.rdd, schema)
+  }
+}

--- a/ingestor/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/TestTestAllNullableParquetStreamWriterObject.scala
+++ b/ingestor/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/TestTestAllNullableParquetStreamWriterObject.scala
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2019 ABSA Group Limited
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.ingestor.implementation.writer.parquet
+
+import org.apache.commons.configuration2.{BaseConfiguration, Configuration}
+import org.scalatest.{BeforeAndAfterEach, FlatSpec}
+import za.co.absa.hyperdrive.shared.configurations.ConfigurationsKeys.ParquetStreamWriterKeys.{KEY_DESTINATION_DIRECTORY, KEY_EXTRA_CONFS_ROOT}
+
+class TestTestAllNullableParquetStreamWriterObject extends FlatSpec with BeforeAndAfterEach {
+
+  private val configStub: Configuration = new BaseConfiguration()
+
+  private val destinationDirectory = "/tmp/destination/parquet"
+  private val extraConfs = Map("key.1" -> "value.1", "key.2" -> "value.2")
+
+  override def beforeEach(): Unit = configStub.clear()
+
+  behavior of AllNullableParquetStreamWriter.getClass.getSimpleName
+
+  it should "throw on blank destination directory" in {
+    val throwable = intercept[IllegalArgumentException](AllNullableParquetStreamWriter(configStub))
+    assert(throwable.getMessage.toLowerCase.contains("destination"))
+  }
+
+  it should "instantiate a AllNullableParquetStreamWriter instance from configurations" in {
+    stubDestinationDirectory()
+    stubExtraConfs()
+
+    val writer = AllNullableParquetStreamWriter(configStub).asInstanceOf[AllNullableParquetStreamWriter]
+    assert(destinationDirectory == writer.getDestination)
+    val injectedWriter = writer.parquetStreamWriter.asInstanceOf[ParquetStreamWriter]
+    assert(extraConfs.toSet.diff(injectedWriter.extraConfOptions.get.toSet).isEmpty)
+  }
+
+  it should "throw if an extra option is malformed" in {
+    stubDestinationDirectory()
+
+    val writer = AllNullableParquetStreamWriter(configStub).asInstanceOf[AllNullableParquetStreamWriter]
+    assert(destinationDirectory == writer.getDestination)
+    val injectedWriter = writer.parquetStreamWriter.asInstanceOf[ParquetStreamWriter]
+    assert(injectedWriter.extraConfOptions.isEmpty)
+  }
+
+  it should "not throw on absent extra configurations" in {
+    stubDestinationDirectory()
+    stubExtraConfs()
+    stubStringConfig(s"$KEY_EXTRA_CONFS_ROOT.wrong.conf","only.key=")
+
+    assertThrows[IllegalArgumentException](AllNullableParquetStreamWriter(configStub))
+  }
+
+  private def stubStringConfig(key: String, value: String): Unit = configStub.addProperty(key, value)
+
+  private def stubDestinationDirectory(): Unit = stubStringConfig(KEY_DESTINATION_DIRECTORY, destinationDirectory)
+
+  private def stubExtraConfs(): Unit = {
+    extraConfs
+      .zipWithIndex
+      .foreach {
+        case((key,value),index) => stubStringConfig(s"$KEY_EXTRA_CONFS_ROOT.$index", s"$key=$value")
+      }
+  }
+}

--- a/ingestor/shared/src/main/scala/za/co/absa/hyperdrive/shared/test/utils/SparkTestUtils.scala
+++ b/ingestor/shared/src/main/scala/za/co/absa/hyperdrive/shared/test/utils/SparkTestUtils.scala
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2019 ABSA Group Limited
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.shared.test.utils
+
+import org.apache.spark.sql.types.{ArrayType, StructField, StructType}
+
+object SparkTestUtils {
+
+  def areAllFieldsNullable(schema: StructType): Boolean = {
+    schema.fields.forall(isNullable(_))
+  }
+
+  private def isNullable(field: StructField): Boolean = {
+    val inspectionResult = field match {
+      case dt: StructType => areAllFieldsNullable(dt)
+      case dt: ArrayType => areAllFieldsNullable(dt)
+      case dt: StructField => dt.nullable
+    }
+
+    inspectionResult && field.nullable
+  }
+
+  private def areAllFieldsNullable(arrayType: ArrayType): Boolean = {
+    arrayType.elementType match {
+      case dt: ArrayType => dt.containsNull && areAllFieldsNullable(dt)
+      case dt: StructType => areAllFieldsNullable(dt)
+      case dt: StructField => dt.nullable
+    }
+  }
+}

--- a/ingestor/shared/src/main/scala/za/co/absa/hyperdrive/shared/utils/SparkUtils.scala
+++ b/ingestor/shared/src/main/scala/za/co/absa/hyperdrive/shared/utils/SparkUtils.scala
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2019 ABSA Group Limited
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.shared.utils
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.{ArrayType, StructField, StructType}
+
+object SparkUtils {
+
+  def setAllColumnsNullable(df: DataFrame): DataFrame = {
+    val newSchema = getNullableSchema(df.schema)
+    df.sparkSession.createDataFrame(df.rdd, newSchema)
+  }
+
+  private def getNullableSchema(schema: StructType): StructType = {
+    StructType(schema.fields.map(field =>
+      field.dataType match {
+        case dt: StructType =>
+          StructField(field.name, getNullableSchema(dt), nullable = true, field.metadata)
+        case dt: ArrayType =>
+          StructField(field.name, getNullableArray(dt), nullable = true, field.metadata)
+        case dt =>
+          StructField(field.name, dt, nullable = true, field.metadata)
+      }
+    ))
+  }
+
+  private def getNullableArray(arrayType: ArrayType): ArrayType = {
+    arrayType.elementType match {
+      case dt: ArrayType =>
+        ArrayType(getNullableArray(dt), containsNull = true)
+      case dt: StructType =>
+        ArrayType(getNullableSchema(dt), containsNull = true)
+      case dt =>
+        ArrayType(dt, containsNull = true)
+    }
+  }
+}

--- a/ingestor/shared/src/test/scala/za/co/absa/hyperdrive/shared/utils/TestSparkUtils.scala
+++ b/ingestor/shared/src/test/scala/za/co/absa/hyperdrive/shared/utils/TestSparkUtils.scala
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2019 ABSA Group Limited
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.shared.utils
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.types._
+import org.scalatest.FunSuite
+import SparkUtils._
+import za.co.absa.hyperdrive.shared.test.utils.SparkTestUtils._
+
+class TestSparkUtils extends FunSuite {
+
+  private val spark = SparkSession.builder().appName(classOf[TestSparkUtils].getSimpleName).master("local").getOrCreate()
+
+  test(testName = "set fields to nullable") {
+
+    val nestedType1 = new StructType()
+      .add(StructField("a", IntegerType, false))
+      .add(StructField("b", LongType, false))
+
+    val nestedType2 = new StructType()
+      .add(StructField("c", ArrayType(nestedType1, false), false))
+
+    val schema = new StructType()
+      .add(StructField("d", StringType, false))
+      .add(StructField("e", ArrayType(nestedType2, false), false))
+
+    val nonNullableDf = spark.createDataFrame(spark.emptyDataFrame.rdd, schema)
+    assert(!areAllFieldsNullable(schema))
+
+    val nullableDf = setAllColumnsNullable(nonNullableDf)
+    assert(!areAllFieldsNullable(schema))
+  }
+}


### PR DESCRIPTION
Parquet sets all columns nullability to true anyway, as described [here](https://spark.apache.org/docs/latest/sql-data-sources-parquet.html), so in some situations it might be helpful to force it to true before any verifications are performed while writing (e.g. getting the data written anyway for later debugging).