### PR TITLE
Upgrading decoder to use ABRiS 3.

### DIFF
--- a/driver/src/main/resources/Ingestion.properties.template
+++ b/driver/src/main/resources/Ingestion.properties.template
@@ -23,7 +23,7 @@ component.reader=za.co.absa.hyperdrive.ingestor.implementation.reader.kafka.Kafk
 component.decoder=za.co.absa.hyperdrive.ingestor.implementation.decoder.avro.confluent.ConfluentAvroKafkaStreamDecoder
 component.manager=za.co.absa.hyperdrive.ingestor.implementation.manager.checkpoint.CheckpointOffsetManager
 component.transformer=za.co.absa.hyperdrive.ingestor.implementation.transformer.column.selection.ColumnSelectorStreamTransformer
-component.writer=za.co.absa.hyperdrive.ingestor.implementation.writer.parquet.AllNullableParquetStreamWriter
+component.writer=za.co.absa.hyperdrive.ingestor.implementation.writer.parquet.ParquetStreamWriter
 
 # Spark settings
 ingestor.spark.app.name=ingestor-app-pane

--- a/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/decoder/avro/confluent/ConfluentAvroKafkaStreamDecoder.scala
+++ b/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/decoder/avro/confluent/ConfluentAvroKafkaStreamDecoder.scala
@@ -55,8 +55,9 @@ private[decoder] class ConfluentAvroKafkaStreamDecoder(val topic: String, val sc
     val schemaRegistryFullSettings = schemaRegistrySettings + (SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC -> topic)
     logger.info(s"SchemaRegistry settings: $schemaRegistryFullSettings")
 
-    import za.co.absa.abris.avro.AvroSerDe._
-    streamReader.fromConfluentAvro(column = "value", None, Some(schemaRegistryFullSettings))(retentionPolicy)
+    import za.co.absa.abris.avro.functions.from_confluent_avro
+    import org.apache.spark.sql.functions.col
+    streamReader.load().select(from_confluent_avro(col("value"), schemaRegistryFullSettings) as 'data).select("data.*")
   }
 }
 

--- a/parent-conf/pom.xml
+++ b/parent-conf/pom.xml
@@ -43,7 +43,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!--ABRiS-->
-        <abris.version>2.2.2</abris.version>
+        <abris.version>3.0.1</abris.version>
 
         <!--Scala-->
         <scala.version>2.11.8</scala.version>


### PR DESCRIPTION
ABRiS 2 was not supporting Avro schema evolution as we need, but ABRiS 3 is.