### PR TITLE
Feature/add buildnumber maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,3 @@ dependency-reduced-pom.xml
 _testOutput
 output
 /keystore/
-
-*.properties

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -82,7 +82,10 @@
                             </relocations>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>za.co.absa.hyperdrive.driver.drivers.PropertiesIngestionDriver</mainClass>
+                                    <manifestEntries>
+                                        <Main-Class>za.co.absa.hyperdrive.driver.drivers.PropertiesIngestionDriver</Main-Class>
+                                        <Implementation-Version>${buildNumber}</Implementation-Version>
+                                    </manifestEntries>
                                 </transformer>
                             </transformers>
                             <filters>

--- a/driver/src/main/resources/version.properties
+++ b/driver/src/main/resources/version.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2018-2019 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+project.version=${project.version}
+implementation.version=${buildNumber}

--- a/driver/src/main/scala/za/co/absa/hyperdrive/driver/drivers/CommandLineIngestionDriver.scala
+++ b/driver/src/main/scala/za/co/absa/hyperdrive/driver/drivers/CommandLineIngestionDriver.scala
@@ -19,6 +19,7 @@ import org.apache.commons.configuration2.Configuration
 import org.apache.commons.configuration2.BaseConfiguration
 import org.apache.logging.log4j.LogManager
 import za.co.absa.hyperdrive.driver.IngestionDriver
+import za.co.absa.hyperdrive.driver.utils.DriverUtil
 
 object CommandLineIngestionDriver extends IngestionDriver {
 
@@ -28,6 +29,8 @@ object CommandLineIngestionDriver extends IngestionDriver {
     if (args.isEmpty) {
       throw new IllegalArgumentException("No configuration provided.")
     }
+
+    logger.info(s"Starting Hyperdrive ${DriverUtil.getVersionString}")
 
     logger.info(s"Going to load ${args.length} configurations from command line.")
     val configuration = parseConfiguration(args)

--- a/driver/src/main/scala/za/co/absa/hyperdrive/driver/drivers/PropertiesIngestionDriver.scala
+++ b/driver/src/main/scala/za/co/absa/hyperdrive/driver/drivers/PropertiesIngestionDriver.scala
@@ -23,6 +23,7 @@ import org.apache.commons.configuration2.builder.fluent.Parameters
 import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler
 import org.apache.logging.log4j.LogManager
 import za.co.absa.hyperdrive.driver.IngestionDriver
+import za.co.absa.hyperdrive.driver.utils.DriverUtil
 
 /**
   * This driver launches ingestion by loading the configurations from a properties file.
@@ -36,6 +37,7 @@ object PropertiesIngestionDriver extends IngestionDriver {
     if (propertiesFile.isEmpty) {
       throw new IllegalArgumentException("No properties file supplied.")
     }
+    logger.info(s"Starting Hyperdrive ${DriverUtil.getVersionString}")
 
     if (isInvalid(propertiesFile.get)) {
       throw new IllegalArgumentException(s"Invalid properties file: '${propertiesFile.get}'.")

--- a/driver/src/main/scala/za/co/absa/hyperdrive/driver/utils/DriverUtil.scala
+++ b/driver/src/main/scala/za/co/absa/hyperdrive/driver/utils/DriverUtil.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.driver.utils
+
+import java.util.Properties
+
+import scala.util.Try
+
+
+object DriverUtil {
+
+  private val VERSIONS_FILE = "version.properties"
+  private val PROJECT_VERSION_KEY = "project.version"
+  private val IMPLEMENTATION_VERSION_KEY = "implementation.version"
+  private val UNKNOWN = "<unknown>"
+
+  def getVersionString: String = {
+    val versions = getVersions
+    s"Version: ${versions._1 getOrElse UNKNOWN}, Implementation-Version: ${versions._2 getOrElse UNKNOWN}"
+  }
+
+  private def getVersions: (Option[String], Option[String]) = {
+    Try {
+      val properties = new Properties()
+      properties.load(getClass.getClassLoader.getResourceAsStream(VERSIONS_FILE))
+      (Option(properties.getProperty(PROJECT_VERSION_KEY)), Option(properties.getProperty(IMPLEMENTATION_VERSION_KEY)))
+    } getOrElse ((None, None))
+  }
+}

--- a/driver/src/test/scala/za/co/absa/hyperdrive/driver/util/TestDriverUtil.scala
+++ b/driver/src/test/scala/za/co/absa/hyperdrive/driver/util/TestDriverUtil.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.driver.util
+
+import org.scalatest.{FlatSpec, Matchers}
+import za.co.absa.hyperdrive.driver.utils.DriverUtil
+
+class TestDriverUtil extends FlatSpec with Matchers {
+  behavior of "DriverUtil"
+
+  it should "print the implementation version" in {
+    // when
+    val versionString = DriverUtil.getVersionString
+
+    // then
+    versionString should not be "Version: ${project.version}, Implementation-Version: ${buildNumnber}"
+    versionString should fullyMatch regex "Version: .*, Implementation-Version: [a-zA-ZZ0-9]{8}"
+  }
+}

--- a/parent-conf/pom.xml
+++ b/parent-conf/pom.xml
@@ -83,6 +83,8 @@
         <!--Configurations-->
         <commons.configuration2.version>2.4</commons.configuration2.version>
         <commons.beanutils.version>1.9.3</commons.beanutils.version>
+
+        <buildnumber.maven.version>1.4</buildnumber.maven.version>
     </properties>
 
     <dependencies>
@@ -285,6 +287,12 @@
     </dependencyManagement>
 
     <build>
+        <resources>
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
         <plugins>
             <!-- the Maven Scala plugin will compile Scala source files -->
             <plugin>
@@ -362,6 +370,23 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <version>${buildnumber.maven.version}</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <shortRevisionLength>8</shortRevisionLength>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
**Outcome**
1. Added Entry "Implementation-Version" in Manifest of driver
```
$ unzip -p driver-1.0.1-SNAPSHOT.jar META-INF/MANIFEST.MF
Manifest-Version: 1.0
Implementation-Version: 3533ba3e
Archiver-Version: Plexus Archiver
Built-By: abkw142
Created-By: Apache Maven 3.6.1
Build-Jdk: 1.8.0_222
Main-Class: za.co.absa.hyperdrive.driver.drivers.PropertiesIngestionDr
 iver
```

2. Implementation-Version logged when starting driver
```
$ spark-submit driver-1.0.1-SNAPSHOT.jar Ingestion.template
10:35:08.068 [main] INFO  za.co.absa.hyperdrive.driver.drivers.PropertiesIngestionDriver$ - Starting Hyperdrive Version: 1.0.1-SNAPSHOT, Implementation-Version: 8259a9ef
```