### PR TITLE
Delete destination directory when exception occurred during ingestion

### DIFF
--- a/driver/src/main/scala/za/co/absa/hyperdrive/driver/SparkIngestor.scala
+++ b/driver/src/main/scala/za/co/absa/hyperdrive/driver/SparkIngestor.scala
@@ -17,6 +17,7 @@ package za.co.absa.hyperdrive.driver
 
 import java.util.UUID
 
+import org.apache.hadoop.fs.{FileSystem, LocatedFileStatus, Path}
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.sql.SparkSession
 import za.co.absa.hyperdrive.ingestor.api.decoder.StreamDecoder
@@ -27,6 +28,7 @@ import za.co.absa.hyperdrive.ingestor.api.transformer.StreamTransformer
 import za.co.absa.hyperdrive.ingestor.api.writer.StreamWriter
 import za.co.absa.hyperdrive.shared.exceptions.{IngestionException, IngestionStartException}
 
+import scala.collection.AbstractIterator
 import scala.util.control.NonFatal
 
 /**
@@ -70,6 +72,7 @@ object SparkIngestor {
 
     logger.info(s"STARTING ingestion from '${streamReader.getSourceName}' into '${streamWriter.getDestination}' (id = $ingestionId)")
 
+    val destinationEmptyBefore = isDestinationEmpty(spark, streamWriter.getDestination)
     val ingestionQuery = try {
       val inputStream = streamReader.read(spark) // gets the source stream
       val configuredStreamReader = offsetManager.configureOffsets(inputStream, spark.sparkContext.hadoopConfiguration) // does offset management if any
@@ -87,6 +90,9 @@ object SparkIngestor {
       ingestionFinalizer.finalize(ingestionQuery)
     } catch {
       case NonFatal(e) =>
+        if(destinationEmptyBefore) {
+          cleanupDestination(spark, streamWriter.getDestination)
+        }
         throw new IngestionException(message = s"PROBABLY FAILED INGESTION $ingestionId. There was no error in the query plan, but something when wrong. " +
           s"Pay attention to this exception since the query has been started, which might lead to duplicate data or similar issues. " +
           s"The logs should have enough detail, but a possible course of action is to replay this ingestion and overwrite the destination.", e)
@@ -132,4 +138,26 @@ object SparkIngestor {
   }
 
   private def generateIngestionId: String = UUID.randomUUID().toString
+
+  private def isDestinationEmpty(spark: SparkSession, destinationDirectory: String): Boolean = {
+    val fs = FileSystem.get(spark.sparkContext.hadoopConfiguration)
+    val destinationPath = new Path(destinationDirectory)
+    !fs.exists(destinationPath) || !fs.listFiles(destinationPath, true).hasNext
+  }
+
+  private def cleanupDestination(spark: SparkSession, destinationDirectory: String): Unit = {
+    val fs = FileSystem.get(spark.sparkContext.hadoopConfiguration)
+    val destinationPath = new Path(destinationDirectory)
+
+    if(fs.exists(destinationPath)) {
+      val filesIterator = fs.listFiles(destinationPath, true)
+      val filesList = new AbstractIterator[LocatedFileStatus] {
+        override def hasNext: Boolean = filesIterator.hasNext
+        override def next: LocatedFileStatus = filesIterator.next
+      }.map(f => f.getPath).toList
+      logger.info(s"Deleting directory $destinationDirectory with ${filesList.size} files: ${filesList.mkString(", ")}")
+
+      fs.delete(destinationPath, true)
+    }
+  }
 }


### PR DESCRIPTION
Problem: If e.g. one task fails writing, the ingestion will be incomplete and an IngestionException is thrown. However, the output directory is not cleaned up. For streaming queries, Spark does not yet delete the written files when a task is aborted. This is only planned with Spark v3.0.0 (https://issues.apache.org/jira/browse/SPARK-27254, https://issues.apache.org/jira/browse/SPARK-27210)

This PR: If an exception occurs during ingestion the destination directory is deleted, but only if it was empty before the ingestion started. If the destination directory was not empty in the beginning, it has to be cleaned up manually.
