### PR TITLE
Implementation of partitioning stream writer

### DIFF
--- a/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/AbstractParquetStreamWriter.scala
+++ b/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/AbstractParquetStreamWriter.scala
@@ -17,11 +17,10 @@ package za.co.absa.hyperdrive.ingestor.implementation.writer.parquet
 
 import org.apache.commons.configuration2.Configuration
 import org.apache.commons.lang3.StringUtils
-import org.apache.logging.log4j.LogManager
 import org.apache.spark.sql.streaming.{DataStreamWriter, OutputMode, StreamingQuery, Trigger}
 import org.apache.spark.sql.{DataFrame, Row}
 import za.co.absa.hyperdrive.ingestor.api.manager.OffsetManager
-import za.co.absa.hyperdrive.ingestor.api.writer.{StreamWriter, StreamWriterFactory}
+import za.co.absa.hyperdrive.ingestor.api.writer.StreamWriter
 import za.co.absa.hyperdrive.shared.configurations.ConfigurationsKeys.ParquetStreamWriterKeys.{KEY_DESTINATION_DIRECTORY, KEY_EXTRA_CONFS_ROOT}
 import za.co.absa.hyperdrive.shared.utils.ConfigUtils.getOrThrow
 

--- a/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/AbstractParquetStreamWriter.scala
+++ b/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/AbstractParquetStreamWriter.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.ingestor.implementation.writer.parquet
+
+import org.apache.commons.configuration2.Configuration
+import org.apache.commons.lang3.StringUtils
+import org.apache.logging.log4j.LogManager
+import org.apache.spark.sql.streaming.{DataStreamWriter, OutputMode, StreamingQuery, Trigger}
+import org.apache.spark.sql.{DataFrame, Row}
+import za.co.absa.hyperdrive.ingestor.api.manager.OffsetManager
+import za.co.absa.hyperdrive.ingestor.api.writer.{StreamWriter, StreamWriterFactory}
+import za.co.absa.hyperdrive.shared.configurations.ConfigurationsKeys.ParquetStreamWriterKeys.{KEY_DESTINATION_DIRECTORY, KEY_EXTRA_CONFS_ROOT}
+import za.co.absa.hyperdrive.shared.utils.ConfigUtils.getOrThrow
+
+import scala.util.{Failure, Success, Try}
+
+private[writer] abstract class AbstractParquetStreamWriter(destination: String, val extraConfOptions: Option[Map[String, String]]) extends StreamWriter(destination) {
+
+  if (StringUtils.isBlank(destination)) {
+    throw new IllegalArgumentException(s"Invalid PARQUET destination: '$destination'")
+  }
+
+  def write(dataFrame: DataFrame, offsetManager: OffsetManager): StreamingQuery = {
+    if (dataFrame == null) {
+      throw new IllegalArgumentException("Null DataFrame.")
+    }
+
+    if (offsetManager == null) {
+      throw new IllegalArgumentException("Null OffsetManager instance.")
+    }
+
+    val outStream = getOutStream(dataFrame)
+
+    val streamWithOptions = addOptions(outStream, extraConfOptions)
+
+    val streamWithOptionsAndOffset = configureOffsets(streamWithOptions, offsetManager, dataFrame.sparkSession.sparkContext.hadoopConfiguration)
+
+    streamWithOptionsAndOffset.start(destination)
+  }
+
+  protected def getOutStream(dataFrame: DataFrame): DataStreamWriter[Row] = {
+    dataFrame
+      .writeStream
+      .trigger(Trigger.Once())
+      .format(source = "parquet")
+      .outputMode(OutputMode.Append())
+  }
+
+  protected def addOptions(outStream: DataStreamWriter[Row], extraConfOptions: Option[Map[String, String]]): DataStreamWriter[Row] = {
+    extraConfOptions match {
+      case Some(options) => options.foldLeft(outStream) {
+        case (previousOutStream, (optionKey, optionValue)) => previousOutStream.option(optionKey, optionValue)
+      }
+      case None => outStream
+    }
+  }
+
+  protected def configureOffsets(outStream: DataStreamWriter[Row], offsetManager: OffsetManager, configuration: org.apache.hadoop.conf.Configuration): DataStreamWriter[Row] = offsetManager.configureOffsets(outStream, configuration)
+}
+
+object AbstractParquetStreamWriter {
+
+  def getDestinationDirectory(configuration: Configuration): String = getOrThrow(KEY_DESTINATION_DIRECTORY, configuration, errorMessage = s"Destination directory not found. Is '$KEY_DESTINATION_DIRECTORY' defined?")
+
+  def getExtraOptions(configuration: Configuration): Option[Map[String, String]] = {
+    import scala.collection.JavaConverters._
+    val extraOptions = configuration.getKeys(KEY_EXTRA_CONFS_ROOT)
+      .asScala
+      .map(key => getKeyValueConf(key, configuration))
+
+    if (extraOptions.nonEmpty) {
+      Some(extraOptions.toMap)
+    } else {
+      None
+    }
+  }
+
+  private def getKeyValueConf(key: String, configuration: Configuration): (String, String) = {
+    Try(parseConf(configuration.getString(key.toString))) match {
+      case Success(keyValue) => keyValue
+      case Failure(exception) => throw new IllegalArgumentException(s"Invalid extra configuration for stream writer: '$key'", exception)
+    }
+  }
+
+  private def parseConf(option: String): (String, String) = {
+    val keyValue = option.split("=")
+    if (keyValue.length == 2) {
+      (keyValue.head.trim(), keyValue.tail.head.trim())
+    } else {
+      throw new IllegalArgumentException(s"Invalid option: '$option'")
+    }
+  }
+}
+
+

--- a/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/ParquetPartitioningStreamWriter.scala
+++ b/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/ParquetPartitioningStreamWriter.scala
@@ -34,10 +34,6 @@ private[writer] class ParquetPartitioningStreamWriter(destination: String, repor
   private val COL_DATE = "hyperdrive_date"
   private val COL_VERSION = "hyperdrive_version"
 
-  if (StringUtils.isBlank(destination)) {
-    throw new IllegalArgumentException(s"Invalid PARQUET destination: '$destination'")
-  }
-
   override protected def getOutStream(dataFrame: DataFrame): DataStreamWriter[Row] = {
     val spark = dataFrame.sparkSession
     val initialVersion = 1

--- a/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/ParquetPartitioningStreamWriter.scala
+++ b/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/ParquetPartitioningStreamWriter.scala
@@ -19,7 +19,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 import org.apache.commons.configuration2.Configuration
-import org.apache.commons.lang3.StringUtils
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.sql.execution.streaming.FileStreamSink
 import org.apache.spark.sql.functions.{lit, to_date}

--- a/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/ParquetPartitioningStreamWriter.scala
+++ b/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/ParquetPartitioningStreamWriter.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.ingestor.implementation.writer.parquet
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+import org.apache.commons.configuration2.Configuration
+import org.apache.commons.lang3.StringUtils
+import org.apache.logging.log4j.LogManager
+import org.apache.spark.sql.execution.streaming.FileStreamSink
+import org.apache.spark.sql.functions.{lit, to_date}
+import org.apache.spark.sql.streaming.{DataStreamWriter, OutputMode, Trigger}
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import za.co.absa.hyperdrive.ingestor.api.writer.{StreamWriter, StreamWriterFactory}
+import za.co.absa.hyperdrive.ingestor.implementation.writer.parquet.AbstractParquetStreamWriter._
+import za.co.absa.hyperdrive.shared.configurations.ConfigurationsKeys.ParquetPartitioningStreamWriterKeys._
+
+
+private[writer] class ParquetPartitioningStreamWriter(destination: String, reportDate: String, extraConfOptions: Option[Map[String, String]]) extends AbstractParquetStreamWriter(destination, extraConfOptions) {
+  private val COL_DATE = "hyperdrive_date"
+  private val COL_VERSION = "hyperdrive_version"
+
+  if (StringUtils.isBlank(destination)) {
+    throw new IllegalArgumentException(s"Invalid PARQUET destination: '$destination'")
+  }
+
+  override protected def getOutStream(dataFrame: DataFrame): DataStreamWriter[Row] = {
+    val spark = dataFrame.sparkSession
+    val initialVersion = 1
+    val nextVersion = findNextVersion(spark, initialVersion)
+    val dfWithDate = dataFrame
+      .withColumn(COL_DATE, to_date(lit(reportDate), ParquetPartitioningStreamWriter.reportDateFormat))
+      .withColumn(COL_VERSION, lit(nextVersion))
+
+    dfWithDate
+      .writeStream
+      .trigger(Trigger.Once())
+      .format(source = "parquet")
+      .partitionBy(COL_DATE, COL_VERSION)
+      .outputMode(OutputMode.Append())
+  }
+
+  private def findNextVersion(spark: SparkSession, initialVersion: Int): Int = {
+    if (!FileStreamSink.hasMetadata(Seq(destination), spark.sparkContext.hadoopConfiguration)) {
+      initialVersion
+    } else {
+      import spark.implicits._
+      val df = spark.read.parquet(destination)
+      val versions = df.select(df(COL_VERSION))
+        .filter(df(COL_DATE) === lit(reportDate))
+        .distinct()
+        .as[Int]
+        .collect().toList
+
+      if (versions.nonEmpty) versions.max + 1 else initialVersion
+    }
+  }
+}
+
+object ParquetPartitioningStreamWriter extends StreamWriterFactory {
+  val reportDateFormat: String = "yyyy-MM-dd"
+  val reportDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern(reportDateFormat)
+
+  def apply(config: Configuration): StreamWriter = {
+    val destinationDirectory = getDestinationDirectory(config)
+    val reportDateString = getReportDateString(config)
+    val extraOptions = getExtraOptions(config)
+
+    LogManager.getLogger.info(s"Going to create ParquetStreamWriter instance using: destination directory='$destinationDirectory', extra options='$extraOptions'")
+
+    new ParquetPartitioningStreamWriter(destinationDirectory, reportDateString, extraOptions)
+  }
+
+  private def getReportDateString(configuration: Configuration): String = {
+    configuration.getString(KEY_REPORT_DATE) match {
+      case value: String => value
+      case _ => reportDateFormatter.format(LocalDate.now())
+    }
+  }
+}

--- a/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/ParquetStreamWriter.scala
+++ b/ingestor-default/src/main/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/ParquetStreamWriter.scala
@@ -16,60 +16,11 @@
 package za.co.absa.hyperdrive.ingestor.implementation.writer.parquet
 
 import org.apache.commons.configuration2.Configuration
-import org.apache.commons.lang3.StringUtils
 import org.apache.logging.log4j.LogManager
-import org.apache.spark.sql.streaming.{DataStreamWriter, OutputMode, StreamingQuery, Trigger}
-import org.apache.spark.sql.{DataFrame, Row}
-import za.co.absa.hyperdrive.ingestor.api.manager.OffsetManager
 import za.co.absa.hyperdrive.ingestor.api.writer.{StreamWriter, StreamWriterFactory}
-import za.co.absa.hyperdrive.shared.configurations.ConfigurationsKeys.ParquetStreamWriterKeys.{KEY_DESTINATION_DIRECTORY, KEY_EXTRA_CONFS_ROOT}
-import za.co.absa.hyperdrive.shared.utils.ConfigUtils.getOrThrow
+import za.co.absa.hyperdrive.ingestor.implementation.writer.parquet.AbstractParquetStreamWriter._
 
-import scala.util.{Failure, Success, Try}
-
-private[writer] class ParquetStreamWriter(destination: String, val extraConfOptions: Option[Map[String, String]]) extends StreamWriter(destination) {
-
-  if (StringUtils.isBlank(destination)) {
-    throw new IllegalArgumentException(s"Invalid PARQUET destination: '$destination'")
-  }
-
-  def write(dataFrame: DataFrame, offsetManager: OffsetManager): StreamingQuery = {
-    if (dataFrame == null) {
-      throw new IllegalArgumentException("Null DataFrame.")
-    }
-
-    if (offsetManager == null) {
-      throw new IllegalArgumentException("Null OffsetManager instance.")
-    }
-
-    val outStream = getOutStream(dataFrame)
-
-    val streamWithOptions = addOptions(outStream, extraConfOptions)
-
-    val streamWithOptionsAndOffset = configureOffsets(streamWithOptions, offsetManager, dataFrame.sparkSession.sparkContext.hadoopConfiguration)
-
-    streamWithOptionsAndOffset.start(destination)
-  }
-
-  private def getOutStream(dataFrame: DataFrame): DataStreamWriter[Row] = {
-    dataFrame
-      .writeStream
-      .trigger(Trigger.Once())
-      .format(source = "parquet")
-      .outputMode(OutputMode.Append())
-  }
-
-  private def addOptions(outStream: DataStreamWriter[Row], extraConfOptions: Option[Map[String, String]]): DataStreamWriter[Row] = {
-    extraConfOptions match {
-      case Some(options) => options.foldLeft(outStream) {
-        case (previousOutStream, (optionKey, optionValue)) => previousOutStream.option(optionKey, optionValue)
-      }
-      case None => outStream
-    }
-  }
-
-  private def configureOffsets(outStream: DataStreamWriter[Row], offsetManager: OffsetManager, configuration: org.apache.hadoop.conf.Configuration): DataStreamWriter[Row] = offsetManager.configureOffsets(outStream, configuration)
-}
+private[writer] class ParquetStreamWriter(destination: String, extraConfOptions: Option[Map[String, String]]) extends AbstractParquetStreamWriter(destination, extraConfOptions)
 
 object ParquetStreamWriter extends StreamWriterFactory {
 
@@ -80,36 +31,5 @@ object ParquetStreamWriter extends StreamWriterFactory {
     LogManager.getLogger.info(s"Going to create ParquetStreamWriter instance using: destination directory='$destinationDirectory', extra options='$extraOptions'")
 
     new ParquetStreamWriter(destinationDirectory, extraOptions)
-  }
-
-  private def getDestinationDirectory(configuration: Configuration): String = getOrThrow(KEY_DESTINATION_DIRECTORY, configuration, errorMessage = s"Destination directory not found. Is '$KEY_DESTINATION_DIRECTORY' defined?")
-
-  private def getExtraOptions(configuration: Configuration): Option[Map[String, String]] = {
-    import scala.collection.JavaConverters._
-    val extraOptions = configuration.getKeys(KEY_EXTRA_CONFS_ROOT)
-      .asScala
-      .map(key => getKeyValueConf(key, configuration))
-
-    if (extraOptions.nonEmpty) {
-      Some(extraOptions.toMap)
-    } else {
-      None
-    }
-  }
-
-  private def getKeyValueConf(key: String, configuration: Configuration): (String, String) = {
-    Try(parseConf(configuration.getString(key.toString))) match {
-      case Success(keyValue) => keyValue
-      case Failure(exception) => throw new IllegalArgumentException(s"Invalid extra configuration for stream writer: '$key'", exception)
-    }
-  }
-
-  private def parseConf(option: String): (String, String) = {
-    val keyValue = option.split("=")
-    if (keyValue.length == 2) {
-      (keyValue.head.trim(), keyValue.tail.head.trim())
-    } else {
-      throw new IllegalArgumentException(s"Invalid option: '$option'")
-    }
   }
 }

--- a/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/TestParquetPartitioningStreamWriter.scala
+++ b/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/TestParquetPartitioningStreamWriter.scala
@@ -31,9 +31,9 @@ class TestParquetPartitioningStreamWriter extends FlatSpec with SparkTestBase wi
   private val baseDir = Files.createTempDirectory("testparquetpartitioning").toUri.toString
   private val fs = FileSystem.get(spark.sparkContext.hadoopConfiguration)
 
-  behavior of "ParquetStreamWriter"
+  behavior of "ParquetPartitioningStreamWriter"
 
-  it should "write partitioned by date and version=1 where destination is empty" in {
+  it should "write partitioned by date and version=1 where destination directory is empty" in {
     // given
     val testDir = s"$baseDir/${UUID.randomUUID().toString}"
     val destinationDir = s"$testDir/destination"

--- a/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/TestParquetPartitioningStreamWriter.scala
+++ b/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/TestParquetPartitioningStreamWriter.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.ingestor.implementation.writer.parquet
+
+import java.nio.file.Files
+import java.util.UUID
+
+import org.apache.commons.configuration2.BaseConfiguration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.functions.lit
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import za.co.absa.hyperdrive.ingestor.implementation.manager.checkpoint.CheckpointOffsetManager
+import za.co.absa.hyperdrive.testutils.SparkTestBase
+
+class TestParquetPartitioningStreamWriter extends FlatSpec with SparkTestBase with Matchers with BeforeAndAfter {
+
+  private val baseDir = Files.createTempDirectory("testparquetpartitioning").toUri.toString
+  private val fs = FileSystem.get(spark.sparkContext.hadoopConfiguration)
+
+  behavior of "ParquetStreamWriter"
+
+  it should "write partitioned by date and version=1 where destination is empty" in {
+    // given
+    val testDir = s"$baseDir/${UUID.randomUUID().toString}"
+    val destinationDir = s"$testDir/destination"
+    val checkpointDir = s"$testDir/checkpoint"
+    fs.mkdirs(new Path(destinationDir))
+    fs.mkdirs(new Path(checkpointDir))
+
+    val config = new BaseConfiguration()
+    config.addProperty("reader.kafka.topic", "testparquetpartitioning")
+    config.addProperty("manager.checkpoint.base.location", checkpointDir)
+    config.addProperty("writer.parquet.destination.directory", destinationDir)
+    config.addProperty("writer.parquet.partitioning.report.date", "2020-02-29")
+
+    val offsetManager = CheckpointOffsetManager(config)
+    val underTest = ParquetPartitioningStreamWriter(config)
+    val df = getDummyReadStream().toDF()
+
+    // when
+    val streamingQuery = underTest.write(df, offsetManager)
+    streamingQuery.processAllAvailable()
+
+    // then
+    fs.exists(new Path(s"$destinationDir/hyperdrive_date=2020-02-29/hyperdrive_version=1")) shouldBe true
+    import spark.implicits._
+    spark.read.parquet(destinationDir)
+      .select("value").map(_ (0).asInstanceOf[Int]).collect() should contain theSameElementsAs List.range(0, 100)
+  }
+
+  it should "write to partition version=2 when version=1 already exists for the same date" in {
+    // given
+    val testDir = s"$baseDir/${UUID.randomUUID().toString}"
+    val destinationDir = s"$testDir/destination"
+    val checkpointDir = s"$testDir/checkpoint"
+    fs.mkdirs(new Path(destinationDir))
+    fs.mkdirs(new Path(checkpointDir))
+
+    val config = new BaseConfiguration()
+    config.addProperty("reader.kafka.topic", "testparquetpartitioning")
+    config.addProperty("manager.checkpoint.base.location", checkpointDir)
+    config.addProperty("writer.parquet.destination.directory", destinationDir)
+    config.addProperty("writer.parquet.partitioning.report.date", "2020-02-29")
+
+    val previousDayConfig = new BaseConfiguration()
+    previousDayConfig.addProperty("writer.parquet.destination.directory", destinationDir)
+    previousDayConfig.addProperty("writer.parquet.partitioning.report.date", "2020-02-28")
+
+    val offsetManager = CheckpointOffsetManager(config)
+    val previousDayWriter = ParquetPartitioningStreamWriter(previousDayConfig)
+    val underTest = ParquetPartitioningStreamWriter(config)
+
+    // when
+    val stream = getDummyReadStream()
+    previousDayWriter.write(stream.toDF(), offsetManager).processAllAvailable()
+    stream.addData(List.range(1000, 1100))
+    previousDayWriter.write(stream.toDF(), offsetManager).processAllAvailable()
+
+    stream.addData(List.range(2000, 2100))
+    underTest.write(stream.toDF(), offsetManager).processAllAvailable()
+    stream.addData(List.range(3000, 3100))
+    underTest.write(stream.toDF(), offsetManager).processAllAvailable()
+
+    // then
+    fs.exists(new Path(s"$destinationDir/hyperdrive_date=2020-02-29/hyperdrive_version=1")) shouldBe true
+    fs.exists(new Path(s"$destinationDir/hyperdrive_date=2020-02-29/hyperdrive_version=2")) shouldBe true
+
+    import spark.implicits._
+    val df = spark.read.parquet(destinationDir)
+    df.select("value")
+      .filter(df("hyperdrive_date") === lit("2020-02-29"))
+      .filter(df("hyperdrive_version") === 1)
+      .map(_ (0).asInstanceOf[Int]).collect() should contain theSameElementsAs List.range(2000, 2100)
+
+    val df2 = spark.read.parquet(destinationDir)
+    df2.select("value")
+      .filter(df2("hyperdrive_date") === lit("2020-02-29"))
+      .filter(df2("hyperdrive_version") === 2)
+      .map(_ (0).asInstanceOf[Int]).collect() should contain theSameElementsAs List.range(3000, 3100)
+  }
+
+  after {
+    fs.delete(new Path(baseDir), true)
+  }
+
+  private def getDummyReadStream() = {
+    import spark.implicits._
+    val input = MemoryStream[Int](1, spark.sqlContext)
+    input.addData(List.range(0, 100))
+    input
+  }
+}

--- a/shared/src/main/scala/za/co/absa/hyperdrive/shared/configurations/ConfigurationsKeys.scala
+++ b/shared/src/main/scala/za/co/absa/hyperdrive/shared/configurations/ConfigurationsKeys.scala
@@ -84,4 +84,9 @@ object ConfigurationsKeys {
     val KEY_DESTINATION_DIRECTORY = s"$rootFactoryConfKey.destination.directory"
     val KEY_EXTRA_CONFS_ROOT = s"$rootFactoryConfKey.extra.conf"
   }
+
+  object ParquetPartitioningStreamWriterKeys {
+    val rootFactoryConfKey = s"${ParquetStreamWriterKeys.rootFactoryConfKey}.partitioning"
+    val KEY_REPORT_DATE = s"$rootFactoryConfKey.report.date"
+  }
 }

--- a/testutils/src/main/scala/za/co/absa/hyperdrive/testutils/SparkTestBase.scala
+++ b/testutils/src/main/scala/za/co/absa/hyperdrive/testutils/SparkTestBase.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.hyperdrive.testutils
+
+import org.apache.log4j.{Level, Logger}
+import org.apache.spark.sql.SparkSession
+
+trait SparkTestBase {
+  System.setProperty("user.timezone", "UTC")
+
+  // Do not display INFO entries for tests
+  Logger.getLogger("org").setLevel(Level.WARN)
+
+  implicit val spark: SparkSession = SparkSession.builder().master("local[*]").appName("test")
+    .config("spark.sql.codegen.wholeStage", value = false)
+    .config("spark.driver.bindAddress", "127.0.0.1")
+    .config("spark.driver.host", "127.0.0.1")
+    .config("spark.ui.enabled", "false")
+    .getOrCreate()
+}


### PR DESCRIPTION
**Added new component**: 
`component.writer=za.co.absa.hyperdrive.ingestor.implementation.writer.parquet.ParquetPartitioningStreamWriter`

- Allows multiple ingestions per day
- Data is written to the destination, partitioned according to processing date ("hyperdrive_date") and version ("hyperdrive_version"). The version is incremented for every execution. The initial version is 1.

_Required configuration_
`writer.parquet.destination.directory` (same like for ParquetStreamWriter)
_Optional configuration_
`writer.parquet.partitioning.report.date=yyyy-MM-dd` For debugging or failure recovery purposes, this parameter determines "hyperdrive_date", i.e. into which partition the data is written. Default: Current date