### PR TITLE
#120: Trim key and value, allow empty value in CommandLineIngestorDriver

### DIFF
--- a/driver/src/main/scala/za/co/absa/hyperdrive/driver/drivers/CommandLineIngestionDriver.scala
+++ b/driver/src/main/scala/za/co/absa/hyperdrive/driver/drivers/CommandLineIngestionDriver.scala
@@ -26,6 +26,7 @@ import za.co.absa.hyperdrive.driver.utils.DriverUtil
 object CommandLineIngestionDriver extends IngestionDriver {
 
   private val logger = LogManager.getLogger
+  private val PropertyDelimiter = "="
 
   def main(args: Array[String]): Unit = {
     if (args.isEmpty) {
@@ -52,10 +53,11 @@ object CommandLineIngestionDriver extends IngestionDriver {
   }
 
   private def setOrThrow(setting: String, configuration: Configuration): Unit = {
-    val settingKeyValue = setting.trim.split("=", 2)
-    if (settingKeyValue.length != 2 || settingKeyValue.exists(_.isEmpty)) {
+    if(!setting.contains(PropertyDelimiter)) {
       throw new IllegalArgumentException(s"Invalid setting format: $setting")
+    } else {
+      val settingKeyValue = setting.split(PropertyDelimiter, 2)
+      configuration.setProperty(settingKeyValue(0).trim, settingKeyValue(1).trim)
     }
-    configuration.setProperty(settingKeyValue(0), settingKeyValue(1))
   }
 }

--- a/driver/src/test/resources/ingestion.properties
+++ b/driver/src/test/resources/ingestion.properties
@@ -22,3 +22,5 @@ key.equals.sign.in.value=value1=value2
 some.long = 3000000000
 some.interpolated.value=${some.long}999
 some.properties = key1 = value1, key2=value2, key3=value3
+ key.with.whitespace = the-value
+key.without.value=

--- a/driver/src/test/scala/za/co/absa/hyperdrive/driver/drivers/TestCommandLineIngestionDriver.scala
+++ b/driver/src/test/scala/za/co/absa/hyperdrive/driver/drivers/TestCommandLineIngestionDriver.scala
@@ -36,6 +36,8 @@ class TestCommandLineIngestionDriver extends FlatSpec with Matchers {
     config.getString("key.equals.sign.in.value") shouldBe "value1=value2"
     config.getLong("some.long") shouldBe 3000000000L
     config.getLong("some.interpolated.value") shouldBe 3000000000999L
+    config.getString("key.with.whitespace") shouldBe "the-value"
+    config.containsKey("key.without.value") shouldBe true
 
     val properties = config.getProperties("some.properties")
     properties.getProperty("key1") shouldBe "value1"
@@ -44,7 +46,7 @@ class TestCommandLineIngestionDriver extends FlatSpec with Matchers {
   }
 
   it should "throw if any configuration is malformed" in {
-    val invalidSetting = "key2="
+    val invalidSetting = "key2"
     val invalidConfString = Array("key1=value1,value2", invalidSetting, "key3=value3")
     val throwable = intercept[IllegalArgumentException](CommandLineIngestionDriver.parseConfiguration(invalidConfString))
     assert(throwable.getMessage.toLowerCase.contains(invalidSetting))
@@ -61,7 +63,9 @@ class TestCommandLineIngestionDriver extends FlatSpec with Matchers {
       "key.equals.sign.in.value=value1=value2",
       "some.long=3000000000",
       "some.interpolated.value=${some.long}999",
-      "some.properties=key1 = value1, key2=value2, key3=value3"
+      "some.properties=key1 = value1, key2=value2, key3=value3",
+      " key.with.whitespace = the-value",
+      "key.without.value="
     )
   }
 }

--- a/driver/src/test/scala/za/co/absa/hyperdrive/driver/drivers/TestPropertiesIngestionDriver.scala
+++ b/driver/src/test/scala/za/co/absa/hyperdrive/driver/drivers/TestPropertiesIngestionDriver.scala
@@ -36,6 +36,8 @@ class TestPropertiesIngestionDriver extends FlatSpec with Matchers {
     config.getString("key.equals.sign.in.value") shouldBe "value1=value2"
     config.getLong("some.long") shouldBe 3000000000L
     config.getLong("some.interpolated.value") shouldBe 3000000000999L
+    config.getString("key.with.whitespace") shouldBe "the-value"
+    config.containsKey("key.without.value") shouldBe true
 
     val properties = config.getProperties("some.properties")
     properties.getProperty("key1") shouldBe "value1"


### PR DESCRIPTION
Closes #120 