### PR TITLE
Feature/259 spark 3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Switch scala version
         run: mvn scala-cross-build:change-version --no-transfer-progress -Pscala-${{ matrix.scala }},spark-${{ matrix.spark }}
       - name: Build and run tests
-        run: mvn clean verify --no-transfer-progress -Pscala-${{ matrix.scala }},spark-${{ matrix.spark }},all-tests
+        run: mvn clean verify -X --no-transfer-progress -Pscala-${{ matrix.scala }},spark-${{ matrix.spark }},all-tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,11 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.scala }}-${{ matrix.spark }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.scala }}-${{ matrix.spark }}-
+      - name: Install Maven 3.8.4
+        run: mvn -N wrapper:wrapper -Dmaven=3.8.4
       - name: License check
-        run: mvn clean validate --no-transfer-progress -Plicense-check,spark-2,spark-3,scala-2.12
+        run: ./mvnw clean validate --no-transfer-progress -Plicense-check,spark-2,spark-3,scala-2.12
       - name: Switch scala version
-        run: mvn scala-cross-build:change-version --no-transfer-progress -Pscala-${{ matrix.scala }},spark-${{ matrix.spark }}
+        run: ./mvnw scala-cross-build:change-version --no-transfer-progress -Pscala-${{ matrix.scala }},spark-${{ matrix.spark }}
       - name: Build and run tests
-        run: mvn clean verify -X --no-transfer-progress -Pscala-${{ matrix.scala }},spark-${{ matrix.spark }},all-tests
+        run: ./mvnw clean verify --no-transfer-progress -Pscala-${{ matrix.scala }},spark-${{ matrix.spark }},all-tests

--- a/api/src/test/scala/za/co/absa/hyperdrive/ingestor/api/utils/TestConfigUtils.scala
+++ b/api/src/test/scala/za/co/absa/hyperdrive/ingestor/api/utils/TestConfigUtils.scala
@@ -311,15 +311,12 @@ class TestConfigUtils extends FlatSpec with Matchers with MockitoSugar {
     val config = new BaseConfiguration
     config.addProperty("key1", "")
     config.addProperty("key2", "nay")
-    config.addProperty("key3", "1")
     config.addProperty("key4", 0)
 
     val ex1 = the[Exception] thrownBy ConfigUtils.getOptionalBoolean("key1", config)
     ex1.getMessage should include("key1")
     val ex2 = the[Exception] thrownBy ConfigUtils.getOptionalBoolean("key2", config)
     ex2.getMessage should include("key2")
-    val ex3 = the[Exception] thrownBy ConfigUtils.getOptionalBoolean("key3", config)
-    ex3.getMessage should include("key3")
     val ex4 = the[Exception] thrownBy ConfigUtils.getOptionalBoolean("key4", config)
     ex4.getMessage should include("key4")
   }

--- a/compatibility-api/src/main/scala/za/co/absa/hyperdrive/compatibility/api/CompatibleSparkUtil.scala
+++ b/compatibility-api/src/main/scala/za/co/absa/hyperdrive/compatibility/api/CompatibleSparkUtil.scala
@@ -21,4 +21,6 @@ import org.apache.spark.sql.execution.streaming.MetadataLogFileIndex
 trait CompatibleSparkUtil {
   def createMetadataLogFileIndex(spark: SparkSession, destination: String): MetadataLogFileIndex
   def hasMetadata(spark: SparkSession, destination: String): Boolean
+  def jsonStringToObject(jsonString: String): Object
+  def objectToJsonString(obj: Object): Option[String]
 }

--- a/compatibility-provider/src/main/scala/za/co/absa/hyperdrive/compatibility/provider/CompatibleSparkUtilProvider.scala
+++ b/compatibility-provider/src/main/scala/za/co/absa/hyperdrive/compatibility/provider/CompatibleSparkUtilProvider.scala
@@ -26,4 +26,10 @@ object CompatibleSparkUtilProvider extends CompatibleSparkUtil {
 
   def hasMetadata(spark: SparkSession, destination: String): Boolean =
     SparkUtil.hasMetadata(spark, destination)
+
+  override def jsonStringToObject(jsonString: String): Object =
+    SparkUtil.jsonStringToObject(jsonString)
+
+  override def objectToJsonString(obj: Object): Option[String] =
+    SparkUtil.objectToJsonString(obj)
 }

--- a/compatibility_spark-3/src/main/scala/za/co/absa/hyperdrive/compatibility/impl/SparkUtil.scala
+++ b/compatibility_spark-3/src/main/scala/za/co/absa/hyperdrive/compatibility/impl/SparkUtil.scala
@@ -15,15 +15,35 @@
 
 package za.co.absa.hyperdrive.compatibility.impl
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.avro.util.internal.JacksonUtils
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.{FileStreamSink, MetadataLogFileIndex}
 import za.co.absa.hyperdrive.compatibility.api.CompatibleSparkUtil
 
+import java.io.ByteArrayOutputStream
+
 object SparkUtil extends CompatibleSparkUtil {
+  private lazy val objectMapper = new ObjectMapper()
+
   override def createMetadataLogFileIndex(spark: SparkSession, destination: String): MetadataLogFileIndex =
     new MetadataLogFileIndex(spark, new Path(destination), Map.empty, None)
 
   override def hasMetadata(spark: SparkSession, destination: String): Boolean =
     FileStreamSink.hasMetadata(Seq(destination), spark.sparkContext.hadoopConfiguration, spark.sessionState.conf)
+
+  override def jsonStringToObject(jsonString: String): Object = {
+    val jsonNode = objectMapper.readTree(jsonString)
+    JacksonUtils.toObject(jsonNode)
+  }
+
+  override def objectToJsonString(obj: Object): Option[String] = {
+    Option(JacksonUtils.toJsonNode(obj))
+      .map { json =>
+        val baos = new ByteArrayOutputStream()
+        objectMapper.writeValue(baos, json)
+        baos.toString
+      }
+  }
 }

--- a/component-scanner/pom.xml
+++ b/component-scanner/pom.xml
@@ -35,14 +35,10 @@
 
         <!--Spark-->
         <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_${scala.compat.version}</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_${scala.compat.version}</artifactId>
-            <scope>test</scope>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/component-scanner/pom.xml
+++ b/component-scanner/pom.xml
@@ -33,7 +33,6 @@
             <version>4.6.1-SNAPSHOT</version>
         </dependency>
 
-        <!--Spark-->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/component-scanner/pom.xml
+++ b/component-scanner/pom.xml
@@ -32,12 +32,5 @@
             <artifactId>api_${scala.compat.version}</artifactId>
             <version>4.6.1-SNAPSHOT</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/hyperdrive-release_spark-3/pom.xml
+++ b/hyperdrive-release_spark-3/pom.xml
@@ -59,6 +59,10 @@
                         <configuration>
                             <relocations>
                                 <relocation>
+                                    <pattern>org.apache.commons.text</pattern>
+                                    <shadedPattern>org.apache.shaded.commons.text</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>org.apache.commons.beanutils</pattern>
                                     <shadedPattern>org.apache.shaded.commons.beanutils</shadedPattern>
                                 </relocation>

--- a/ingestor-default/pom.xml
+++ b/ingestor-default/pom.xml
@@ -48,6 +48,12 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!--ABRiS-->
@@ -82,6 +88,22 @@
             <artifactId>mongo-scala-driver_${scala.compat.version}</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/io.netty/netty-all -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>4.1.68.Final</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.12.3</version>
+            <scope>test</scope>
+        </dependency>
+
 
         <!-- Tests -->
         <dependency>

--- a/ingestor-default/pom.xml
+++ b/ingestor-default/pom.xml
@@ -44,6 +44,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- Hadoop -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+        </dependency>
+
         <!--ABRiS-->
         <dependency>
             <groupId>io.confluent</groupId>

--- a/ingestor-default/pom.xml
+++ b/ingestor-default/pom.xml
@@ -43,13 +43,6 @@
             <artifactId>compatibility-provider_${scala.compat.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <!-- Hadoop -->
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-        </dependency>
-
         <!--ABRiS-->
         <dependency>
             <groupId>io.confluent</groupId>

--- a/ingestor-default/pom.xml
+++ b/ingestor-default/pom.xml
@@ -48,12 +48,6 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.avro</groupId>
-                    <artifactId>avro</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!--ABRiS-->
@@ -88,22 +82,6 @@
             <artifactId>mongo-scala-driver_${scala.compat.version}</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <!-- https://mvnrepository.com/artifact/io.netty/netty-all -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-buffer</artifactId>
-            <version>4.1.68.Final</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.12.3</version>
-            <scope>test</scope>
-        </dependency>
-
 
         <!-- Tests -->
         <dependency>

--- a/parent-conf/pom.xml
+++ b/parent-conf/pom.xml
@@ -185,30 +185,6 @@
                 <version>${spark.version}</version>
                 <scope>provided</scope>
             </dependency>
-            <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-common</artifactId>
-                <version>${hadoop.version}</version>
-                <scope>provided</scope>
-                <exclusions>
-                    <exclusion>
-                        <!-- Excluded because version >= 1.10.1 is required for Spark 3.2.0-->
-                        <groupId>org.apache.avro</groupId>
-                        <artifactId>avro</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <!-- Excluded because version >= 2.12.0 is required for Spark 3.2.0 -->
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-databind</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <!-- Excluded because version >= 4.1.68.Final is required for Spark 3.2.0 -->
-                        <groupId>io.netty</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-
-            </dependency>
 
             <!--Kafka-->
             <dependency>

--- a/parent-conf/pom.xml
+++ b/parent-conf/pom.xml
@@ -200,6 +200,12 @@
                 <version>${spark.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-common</artifactId>
+                <version>${hadoop.version}</version>
+                <scope>provided</scope>
+            </dependency>
 
             <!--Kafka-->
             <dependency>

--- a/parent-conf/pom.xml
+++ b/parent-conf/pom.xml
@@ -281,25 +281,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers</artifactId>
-                <version>${testcontainers.kafka.version}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <!-- Excluded because version >= 2.12.0 is required for Spark 3.2.0 -->
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-annotations</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>kafka</artifactId>
-                <version>${testcontainers.kafka.version}</version>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/parent-conf/pom.xml
+++ b/parent-conf/pom.xml
@@ -254,11 +254,6 @@
                         <groupId>com.fasterxml.jackson.core</groupId>
                         <artifactId>jackson-core</artifactId>
                     </exclusion>
-                    <exclusion>
-                        <!-- Excluded because it may not be the same version as from ABRiS -->
-                        <groupId>org.apache.avro</groupId>
-                        <artifactId>avro</artifactId>
-                    </exclusion>
                 </exclusions>
             </dependency>
         </dependencies>

--- a/parent-conf/pom.xml
+++ b/parent-conf/pom.xml
@@ -279,6 +279,11 @@
                         <groupId>com.fasterxml.jackson.core</groupId>
                         <artifactId>jackson-core</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <!-- Excluded because it may not be the same version as from ABRiS -->
+                        <groupId>org.apache.avro</groupId>
+                        <artifactId>avro</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
         </dependencies>

--- a/parent-conf/pom.xml
+++ b/parent-conf/pom.xml
@@ -39,16 +39,12 @@
 
     <properties>
         <!--Enforced versions-->
-        <avro.version>1.8.2</avro.version> <!--Same as Abris uses-->
         <commons.text.version>1.8</commons.text.version>
         <paranamer.version>2.8</paranamer.version>
 
         <!--Maven-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <!--ABRiS-->
-        <abris.version>5.1.1</abris.version>
 
         <!--Scala-->
         <scalatest.version>3.0.5</scalatest.version>
@@ -61,7 +57,7 @@
         <spring.kafka.test.version>2.2.4.RELEASE</spring.kafka.test.version>
         <kafka.spark.version>0-10</kafka.spark.version>
         <testcontainers.kafka.version>1.15.1</testcontainers.kafka.version>
-        <kafka.avro.serializer.version>5.3.4</kafka.avro.serializer.version> <!--Same as Abris uses-->
+        <confluent.version>6.2.1</confluent.version> <!--Same as Abris uses-->
 
         <embedded.mongo.version>2.1.2</embedded.mongo.version>
 
@@ -87,11 +83,6 @@
 
     <dependencies>
         <!--Enforced dependency versions-->
-        <!--Avro-->
-        <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
@@ -100,6 +91,14 @@
             <groupId>com.thoughtworks.paranamer</groupId>
             <artifactId>paranamer</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.12.3</version>
+            <scope>test</scope>
+        </dependency>
+
         <!--END Enforced dependency versions-->
 
         <!--Spark-->
@@ -139,12 +138,6 @@
 
         <dependencies>
             <!--Enforced dependency versions-->
-            <!--Avro-->
-            <dependency>
-                <groupId>org.apache.avro</groupId>
-                <artifactId>avro</artifactId>
-                <version>${avro.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
@@ -269,7 +262,7 @@
                 <!-- Cannot have scope test because it is used by abris -->
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-avro-serializer</artifactId>
-                <version>${kafka.avro.serializer.version}</version>
+                <version>${confluent.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>

--- a/parent-conf/pom.xml
+++ b/parent-conf/pom.xml
@@ -39,7 +39,6 @@
 
     <properties>
         <!--Enforced versions-->
-        <commons.text.version>1.8</commons.text.version>
         <paranamer.version>2.8</paranamer.version>
 
         <!--Maven-->
@@ -81,11 +80,6 @@
     </properties>
 
     <dependencies>
-        <!--Enforced dependency versions-->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.thoughtworks.paranamer</groupId>
             <artifactId>paranamer</artifactId>
@@ -129,11 +123,6 @@
 
         <dependencies>
             <!--Enforced dependency versions-->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-text</artifactId>
-                <version>${commons.text.version}</version>
-            </dependency>
             <dependency>
                 <groupId>com.thoughtworks.paranamer</groupId>
                 <artifactId>paranamer</artifactId>
@@ -183,6 +172,12 @@
                 <artifactId>spark-core_${scala.compat.version}</artifactId>
                 <version>${spark.version}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-text</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!--Kafka-->
@@ -190,6 +185,12 @@
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-sql-kafka-${kafka.spark.version}_${scala.compat.version}</artifactId>
                 <version>${spark.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-client-runtime</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- MongoDb Spark connector -->

--- a/parent-conf/pom.xml
+++ b/parent-conf/pom.xml
@@ -91,14 +91,6 @@
             <groupId>com.thoughtworks.paranamer</groupId>
             <artifactId>paranamer</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.12.3</version>
-            <scope>test</scope>
-        </dependency>
-
         <!--END Enforced dependency versions-->
 
         <!--Spark-->
@@ -198,6 +190,21 @@
                 <artifactId>hadoop-common</artifactId>
                 <version>${hadoop.version}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.avro</groupId>
+                        <artifactId>avro</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-handler</artifactId>
+                    </exclusion>
+                </exclusions>
+
             </dependency>
 
             <!--Kafka-->

--- a/parent-conf/pom.xml
+++ b/parent-conf/pom.xml
@@ -192,16 +192,19 @@
                 <scope>provided</scope>
                 <exclusions>
                     <exclusion>
+                        <!-- Excluded because version >= 1.10.1 is required for Spark 3.2.0-->
                         <groupId>org.apache.avro</groupId>
                         <artifactId>avro</artifactId>
                     </exclusion>
                     <exclusion>
+                        <!-- Excluded because version >= 2.12.0 is required for Spark 3.2.0 -->
                         <groupId>com.fasterxml.jackson.core</groupId>
                         <artifactId>jackson-databind</artifactId>
                     </exclusion>
                     <exclusion>
+                        <!-- Excluded because version >= 4.1.68.Final is required for Spark 3.2.0 -->
                         <groupId>io.netty</groupId>
-                        <artifactId>netty-handler</artifactId>
+                        <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
 
@@ -270,12 +273,26 @@
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-avro-serializer</artifactId>
                 <version>${confluent.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- Excluded because version >= 2.12.0 is required for Spark 3.2.0 -->
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
                 <version>${testcontainers.kafka.version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <!-- Excluded because version >= 2.12.0 is required for Spark 3.2.0 -->
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>

--- a/parent-conf/pom.xml
+++ b/parent-conf/pom.xml
@@ -57,7 +57,6 @@
         <spring.kafka.test.version>2.2.4.RELEASE</spring.kafka.test.version>
         <kafka.spark.version>0-10</kafka.spark.version>
         <testcontainers.kafka.version>1.15.1</testcontainers.kafka.version>
-        <confluent.version>6.2.1</confluent.version> <!--Same as Abris uses-->
 
         <embedded.mongo.version>2.1.2</embedded.mongo.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
 
         <!-- Spark versions -->
         <spark_2.version>2.4.3</spark_2.version>
-        <spark_3.version>3.2.0</spark_3.version>
+        <spark_3.version>3.2.1</spark_3.version>
         <spark_2.sql.mongo.version>2.4.3</spark_2.sql.mongo.version>
         <hadoop_2.version>2.6.5</hadoop_2.version>
         <spark_3.sql.mongo.version>3.0.1</spark_3.sql.mongo.version>
@@ -122,7 +122,7 @@
 
         <!-- ABRiS versions -->
         <abris_spark_24.version>5.1.1</abris_spark_24.version>
-        <abris_spark_32.version>6.1.1</abris_spark_32.version>
+        <abris_spark_32.version>6.2.0</abris_spark_32.version>
 
         <!-- Default versions -->
         <spark.compat.version />
@@ -220,6 +220,14 @@
                 <hadoop.version>${hadoop_3.version}</hadoop.version> <!-- same as Spark -->
                 <abris.version>${abris_spark_32.version}</abris.version>
             </properties>
+            <dependencies>
+                <!-- For some reason, this dependency is not transitively included in spark-core -->
+                <dependency>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-api</artifactId>
+                    <version>3.3.1</version>
+                </dependency>
+            </dependencies>
             <dependencyManagement>
                 <dependencies>
                     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,22 @@
                 <hadoop.version>${hadoop_2.version}</hadoop.version> <!-- same as Spark -->
                 <abris.version>${abris_spark_24.version}</abris.version>
             </properties>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.testcontainers</groupId>
+                        <artifactId>testcontainers</artifactId>
+                        <version>${testcontainers.kafka.version}</version>
+                        <scope>test</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.testcontainers</groupId>
+                        <artifactId>kafka</artifactId>
+                        <version>${testcontainers.kafka.version}</version>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
             <modules>
                 <module>compatibility_spark-2</module>
                 <module>hyperdrive-release_spark-2</module>
@@ -204,6 +220,29 @@
                 <hadoop.version>${hadoop_3.version}</hadoop.version> <!-- same as Spark -->
                 <abris.version>${abris_spark_32.version}</abris.version>
             </properties>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.testcontainers</groupId>
+                        <artifactId>testcontainers</artifactId>
+                        <version>${testcontainers.kafka.version}</version>
+                        <scope>test</scope>
+                        <exclusions>
+                            <exclusion>
+                                <!-- Excluded because version >= 2.12.0 is required for Spark 3.2.0 -->
+                                <groupId>com.fasterxml.jackson.core</groupId>
+                                <artifactId>jackson-annotations</artifactId>
+                            </exclusion>
+                        </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.testcontainers</groupId>
+                        <artifactId>kafka</artifactId>
+                        <version>${testcontainers.kafka.version}</version>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
             <modules>
                 <module>compatibility_spark-3</module>
                 <module>hyperdrive-release_spark-3</module>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,8 @@
         <!-- ABRiS versions -->
         <abris_spark_24.version>5.1.1</abris_spark_24.version>
         <abris_spark_32.version>6.2.0</abris_spark_32.version>
+        <confluent_abris_5.version>5.3.4</confluent_abris_5.version>
+        <confluent_abris_6.version>6.2.1</confluent_abris_6.version>
 
         <!-- Default versions -->
         <spark.compat.version />
@@ -188,6 +190,7 @@
                 <mongodb.driver.version>${spark_2.mongodb.driver.version}</mongodb.driver.version>
                 <hadoop.version>${hadoop_2.version}</hadoop.version> <!-- same as Spark -->
                 <abris.version>${abris_spark_24.version}</abris.version>
+                <confluent.version>${confluent_abris_5.version}</confluent.version>
             </properties>
             <dependencyManagement>
                 <dependencies>
@@ -219,6 +222,7 @@
                 <mongodb.driver.version>${spark_3.mongodb.driver.version}</mongodb.driver.version>
                 <hadoop.version>${hadoop_3.version}</hadoop.version> <!-- same as Spark -->
                 <abris.version>${abris_spark_32.version}</abris.version>
+                <confluent.version>${confluent_abris_6.version}</confluent.version>
             </properties>
             <dependencies>
                 <!-- For some reason, this dependency is not transitively included in spark-core -->

--- a/pom.xml
+++ b/pom.xml
@@ -112,12 +112,13 @@
 
         <!-- Spark versions -->
         <spark_2.version>2.4.3</spark_2.version>
-        <spark_3.version>3.1.2</spark_3.version>
+        <spark_3.version>3.2.1</spark_3.version>
         <spark_2.sql.mongo.version>2.4.3</spark_2.sql.mongo.version>
+        <hadoop_2.version>2.6.5</hadoop_2.version>
         <spark_3.sql.mongo.version>3.0.1</spark_3.sql.mongo.version>
         <spark_2.mongodb.driver.version>2.7.0</spark_2.mongodb.driver.version>
         <spark_3.mongodb.driver.version>4.0.5</spark_3.mongodb.driver.version>
-
+        <hadoop_3.version>3.3.1</hadoop_3.version>
         <!-- Default versions -->
         <spark.compat.version />
         <spark.version />
@@ -180,6 +181,7 @@
                 <spark.version>${spark_2.version}</spark.version>
                 <spark.sql.mongo.version>${spark_2.sql.mongo.version}</spark.sql.mongo.version>
                 <mongodb.driver.version>${spark_2.mongodb.driver.version}</mongodb.driver.version>
+                <hadoop.version>${hadoop_2.version}</hadoop.version> <!-- same as Spark -->
             </properties>
             <modules>
                 <module>compatibility_spark-2</module>
@@ -193,6 +195,7 @@
                 <spark.version>${spark_3.version}</spark.version>
                 <spark.sql.mongo.version>${spark_3.sql.mongo.version}</spark.sql.mongo.version>
                 <mongodb.driver.version>${spark_3.mongodb.driver.version}</mongodb.driver.version>
+                <hadoop.version>${hadoop_3.version}</hadoop.version> <!-- same as Spark -->
             </properties>
             <modules>
                 <module>compatibility_spark-3</module>

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,9 @@
         </profile>
         <profile>
             <id>spark-2</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <properties>
                 <spark.compat.version>spark-2</spark.compat.version>
                 <spark.version>${spark_2.version}</spark.version>
@@ -193,9 +196,6 @@
         </profile>
         <profile>
             <id>spark-3</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <properties>
                 <spark.compat.version>spark-3</spark.compat.version>
                 <spark.version>${spark_3.version}</spark.version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,6 @@
         <spark_2.version>2.4.3</spark_2.version>
         <spark_3.version>3.2.1</spark_3.version>
         <spark_2.sql.mongo.version>2.4.3</spark_2.sql.mongo.version>
-        <hadoop_2.version>2.6.5</hadoop_2.version>
         <spark_3.sql.mongo.version>3.0.1</spark_3.sql.mongo.version>
         <spark_2.mongodb.driver.version>2.7.0</spark_2.mongodb.driver.version>
         <spark_3.mongodb.driver.version>4.0.5</spark_3.mongodb.driver.version>
@@ -188,7 +187,6 @@
                 <spark.version>${spark_2.version}</spark.version>
                 <spark.sql.mongo.version>${spark_2.sql.mongo.version}</spark.sql.mongo.version>
                 <mongodb.driver.version>${spark_2.mongodb.driver.version}</mongodb.driver.version>
-                <hadoop.version>${hadoop_2.version}</hadoop.version> <!-- same as Spark -->
                 <abris.version>${abris_spark_24.version}</abris.version>
                 <confluent.version>${confluent_abris_5.version}</confluent.version>
             </properties>
@@ -220,7 +218,6 @@
                 <spark.version>${spark_3.version}</spark.version>
                 <spark.sql.mongo.version>${spark_3.sql.mongo.version}</spark.sql.mongo.version>
                 <mongodb.driver.version>${spark_3.mongodb.driver.version}</mongodb.driver.version>
-                <hadoop.version>${hadoop_3.version}</hadoop.version> <!-- same as Spark -->
                 <abris.version>${abris_spark_32.version}</abris.version>
                 <confluent.version>${confluent_abris_6.version}</confluent.version>
             </properties>
@@ -229,7 +226,7 @@
                 <dependency>
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-client-api</artifactId>
-                    <version>3.3.1</version>
+                    <version>${hadoop_3.version}</version>
                 </dependency>
             </dependencies>
             <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,7 @@
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-client-api</artifactId>
                     <version>${hadoop_3.version}</version>
+                    <scope>provided</scope>
                 </dependency>
             </dependencies>
             <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
 
         <!-- Spark versions -->
         <spark_2.version>2.4.3</spark_2.version>
-        <spark_3.version>3.2.1</spark_3.version>
+        <spark_3.version>3.2.2</spark_3.version>
         <spark_2.sql.mongo.version>2.4.3</spark_2.sql.mongo.version>
         <spark_3.sql.mongo.version>3.0.1</spark_3.sql.mongo.version>
         <spark_2.mongodb.driver.version>2.7.0</spark_2.mongodb.driver.version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,13 +112,18 @@
 
         <!-- Spark versions -->
         <spark_2.version>2.4.3</spark_2.version>
-        <spark_3.version>3.2.1</spark_3.version>
+        <spark_3.version>3.2.0</spark_3.version>
         <spark_2.sql.mongo.version>2.4.3</spark_2.sql.mongo.version>
         <hadoop_2.version>2.6.5</hadoop_2.version>
         <spark_3.sql.mongo.version>3.0.1</spark_3.sql.mongo.version>
         <spark_2.mongodb.driver.version>2.7.0</spark_2.mongodb.driver.version>
         <spark_3.mongodb.driver.version>4.0.5</spark_3.mongodb.driver.version>
         <hadoop_3.version>3.3.1</hadoop_3.version>
+
+        <!-- ABRiS versions -->
+        <abris_spark_24.version>5.1.1</abris_spark_24.version>
+        <abris_spark_32.version>6.1.1</abris_spark_32.version>
+
         <!-- Default versions -->
         <spark.compat.version />
         <spark.version />
@@ -173,15 +178,13 @@
         </profile>
         <profile>
             <id>spark-2</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <properties>
                 <spark.compat.version>spark-2</spark.compat.version>
                 <spark.version>${spark_2.version}</spark.version>
                 <spark.sql.mongo.version>${spark_2.sql.mongo.version}</spark.sql.mongo.version>
                 <mongodb.driver.version>${spark_2.mongodb.driver.version}</mongodb.driver.version>
                 <hadoop.version>${hadoop_2.version}</hadoop.version> <!-- same as Spark -->
+                <abris.version>${abris_spark_24.version}</abris.version>
             </properties>
             <modules>
                 <module>compatibility_spark-2</module>
@@ -190,12 +193,16 @@
         </profile>
         <profile>
             <id>spark-3</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <properties>
                 <spark.compat.version>spark-3</spark.compat.version>
                 <spark.version>${spark_3.version}</spark.version>
                 <spark.sql.mongo.version>${spark_3.sql.mongo.version}</spark.sql.mongo.version>
                 <mongodb.driver.version>${spark_3.mongodb.driver.version}</mongodb.driver.version>
                 <hadoop.version>${hadoop_3.version}</hadoop.version> <!-- same as Spark -->
+                <abris.version>${abris_spark_32.version}</abris.version>
             </properties>
             <modules>
                 <module>compatibility_spark-3</module>


### PR DESCRIPTION
Closes #259 

Removed a test case in TestConfigUtils that checked that `ConfigUtils.getOptionalBoolean("1")` throws an exception. In that test, `"1"` was simply used as an example for an invalid value. With commons-text v3.10.0, see https://github.com/apache/commons-lang/pull/502, `"1"` was added to the valid values for `true`, therefore indeed no exception is thrown, which is the new expected behavior.