### PR TITLE
Add workaround for embedded mongo db

### DIFF
--- a/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/testutils/mongodb/MongoDbFixture.scala
+++ b/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/testutils/mongodb/MongoDbFixture.scala
@@ -22,6 +22,11 @@ trait MongoDbFixture extends BeforeAndAfterAll {
 
   this: Suite =>
 
+  // Workaround to fix version not supported error
+  if (System.getProperty("os.arch") == "aarch64" && System.getProperty("os.name") == "Mac OS X") {
+    System.setProperty("os.arch", "i686_64")
+  }
+
   import ScalaMongoImplicits._
 
   private val (mongoDbExecutable, mongoPort) = EmbeddedMongoDbSingleton.embeddedMongoDb


### PR DESCRIPTION
Related to #276 and #277

This is the minimal change required to make tests pass on Mac M1 chip (there's no solution yet for docker tests unfortunately)

Tests succeed in IntelliJ and with maven when the spark-3 and scala-2.12 profiles are active.
