### PR TITLE
#286 - Unit tests failing during build

### DIFF
--- a/compatibility_spark-3/src/test/scala/za/co/absa/hyperdrive/compatibility/impl/writer/delta/DeltaTestBase.scala
+++ b/compatibility_spark-3/src/test/scala/za/co/absa/hyperdrive/compatibility/impl/writer/delta/DeltaTestBase.scala
@@ -25,8 +25,11 @@ trait DeltaTestBase extends BeforeAndAfterEach with SparkTestBase {
 
   var baseDir: TempDirectory = _
   def baseDirPath: String = baseDir.path.toAbsolutePath.toString
+  def baseDirUri: String = baseDir.path.toAbsolutePath.toUri.toString
   def destinationPath: String = s"${baseDir.path.toAbsolutePath.toString}/destination"
+  def destinationUri: String = s"${baseDir.path.toAbsolutePath.toUri.toString}/destination"
   def checkpointPath: String = s"${baseDir.path.toAbsolutePath.toString}/checkpoint"
+  def checkpointUri: String = s"${baseDir.path.toAbsolutePath.toUri.toString}/checkpoint"
 
   import spark.implicits._
 

--- a/compatibility_spark-3/src/test/scala/za/co/absa/hyperdrive/compatibility/impl/writer/delta/TestDeltaUtil.scala
+++ b/compatibility_spark-3/src/test/scala/za/co/absa/hyperdrive/compatibility/impl/writer/delta/TestDeltaUtil.scala
@@ -29,7 +29,7 @@ class TestDeltaUtil extends FlatSpec with MockitoSugar with Matchers with DeltaT
   "createDeltaTableIfNotExists" should "create delta table if destination directory is empty" in {
     val schema = StructType(Seq(StructField("testColumn", StringType, nullable = false)))
 
-    DeltaUtil.createDeltaTableIfNotExists(spark, baseDirPath, schema, Seq())
+    DeltaUtil.createDeltaTableIfNotExists(spark, baseDirUri, schema, Seq())
 
     FileUtils.readFileLines(s"$baseDirPath/_delta_log/00000000000000000000.json").nonEmpty shouldBe true
   }
@@ -37,7 +37,7 @@ class TestDeltaUtil extends FlatSpec with MockitoSugar with Matchers with DeltaT
   it should "create delta table if destination directory does not exist" in {
     val schema = StructType(Seq(StructField("testColumn", StringType, nullable = false)))
 
-    DeltaUtil.createDeltaTableIfNotExists(spark, destinationPath, schema, Seq())
+    DeltaUtil.createDeltaTableIfNotExists(spark, destinationUri, schema, Seq())
 
     FileUtils.readFileLines(s"$destinationPath/_delta_log/00000000000000000000.json").nonEmpty shouldBe true
   }
@@ -47,12 +47,12 @@ class TestDeltaUtil extends FlatSpec with MockitoSugar with Matchers with DeltaT
     val dataFolder = new File(destinationPath)
     val deltaLogFolder = new File(s"$destinationPath/_delta_log/")
 
-    DeltaUtil.createDeltaTableIfNotExists(spark, dataFolder.getPath, schema, Seq())
+    DeltaUtil.createDeltaTableIfNotExists(spark, dataFolder.toURI.getPath, schema, Seq())
     FileUtils.readFileLines(s"${deltaLogFolder.getPath}/00000000000000000000.json").nonEmpty shouldBe true
     val contentOfDataFolderFirstExec = dataFolder.list()
     val contentOfDeltaLogFolderFirstExec = deltaLogFolder.list()
 
-    DeltaUtil.createDeltaTableIfNotExists(spark, dataFolder.getPath, schema, Seq())
+    DeltaUtil.createDeltaTableIfNotExists(spark, dataFolder.toURI.getPath, schema, Seq())
     FileUtils.readFileLines(s"${deltaLogFolder.getPath}/00000000000000000000.json").nonEmpty shouldBe true
     val contentOfDataFolderSecondExec = dataFolder.list()
     val contentOfDeltaLogFolderSecondExec = deltaLogFolder.list()
@@ -66,7 +66,7 @@ class TestDeltaUtil extends FlatSpec with MockitoSugar with Matchers with DeltaT
 
     new File(baseDirPath + "/filename.txt").createNewFile()
 
-    assertThrows[IllegalArgumentException](DeltaUtil.createDeltaTableIfNotExists(spark, baseDirPath, schema, Seq()))
+    assertThrows[IllegalArgumentException](DeltaUtil.createDeltaTableIfNotExists(spark, baseDirUri, schema, Seq()))
   }
 
   "getDataFrameWithSortColumns" should "return dataframe with sort columns" in {
@@ -106,23 +106,23 @@ class TestDeltaUtil extends FlatSpec with MockitoSugar with Matchers with DeltaT
   }
 
   "isDirEmptyOrDoesNotExist" should "return true if directory is empty" in {
-    DeltaUtil.isDirEmptyOrDoesNotExist(spark, baseDirPath) shouldBe true
+    DeltaUtil.isDirEmptyOrDoesNotExist(spark, baseDirUri) shouldBe true
   }
 
   it should "return true if directory does not exist" in {
-    DeltaUtil.isDirEmptyOrDoesNotExist(spark, destinationPath) shouldBe true
+    DeltaUtil.isDirEmptyOrDoesNotExist(spark, destinationUri) shouldBe true
   }
 
   it should "return false if directory contains a file" in {
     new File(baseDirPath + "/filename.txt").createNewFile()
 
-    DeltaUtil.isDirEmptyOrDoesNotExist(spark, baseDirPath) shouldBe false
+    DeltaUtil.isDirEmptyOrDoesNotExist(spark, baseDirUri) shouldBe false
   }
 
   it should "return false if path is a file" in {
     val file = new File(baseDirPath + "/filename.txt")
     file.createNewFile()
 
-    DeltaUtil.isDirEmptyOrDoesNotExist(spark, file.getPath) shouldBe false
+    DeltaUtil.isDirEmptyOrDoesNotExist(spark, file.toURI.getPath) shouldBe false
   }
 }

--- a/compatibility_spark-3/src/test/scala/za/co/absa/hyperdrive/compatibility/impl/writer/delta/scd2/TestDeltaCDCToSCD2Writer.scala
+++ b/compatibility_spark-3/src/test/scala/za/co/absa/hyperdrive/compatibility/impl/writer/delta/scd2/TestDeltaCDCToSCD2Writer.scala
@@ -91,9 +91,9 @@ class TestDeltaCDCToSCD2Writer extends FlatSpec with MockitoSugar with Matchers 
   }
 
   private def createDeltaCDCToSCD2Writer(): DeltaCDCToSCD2Writer = new DeltaCDCToSCD2Writer(
-    destination = destinationPath,
+    destination = destinationUri,
     trigger = Trigger.Once(),
-    checkpointLocation = checkpointPath,
+    checkpointLocation = checkpointUri,
     partitionColumns = Seq.empty,
     keyColumn = "id",
     timestampColumn = "timestamp",

--- a/compatibility_spark-3/src/test/scala/za/co/absa/hyperdrive/compatibility/impl/writer/delta/snapshot/TestDeltaCDCToSnapshotWriter.scala
+++ b/compatibility_spark-3/src/test/scala/za/co/absa/hyperdrive/compatibility/impl/writer/delta/snapshot/TestDeltaCDCToSnapshotWriter.scala
@@ -39,9 +39,9 @@ class TestDeltaCDCToSnapshotWriter extends FlatSpec with MockitoSugar with Match
   }
 
   private def createDeltaCDCToSnapshotWriter(): DeltaCDCToSnapshotWriter = new DeltaCDCToSnapshotWriter(
-      destination = destinationPath,
+      destination = destinationUri,
       trigger = Trigger.Once(),
-      checkpointLocation = checkpointPath,
+      checkpointLocation = checkpointUri,
       partitionColumns = Seq.empty,
       keyColumn = "id",
       operationColumn = "eventType",

--- a/driver/src/test/scala/za/co/absa/hyperdrive/driver/drivers/TestPropertiesIngestionDriver.scala
+++ b/driver/src/test/scala/za/co/absa/hyperdrive/driver/drivers/TestPropertiesIngestionDriver.scala
@@ -17,12 +17,14 @@ package za.co.absa.hyperdrive.driver.drivers
 
 import org.scalatest.{FlatSpec, Matchers}
 
+import java.nio.file.Paths
+
 class TestPropertiesIngestionDriver extends FlatSpec with Matchers {
 
   behavior of PropertiesIngestionDriver.getClass.getSimpleName
 
   it should "load all configuration" in {
-    val configurationFilePath = getClass.getClassLoader.getResource("ingestion.properties").getPath
+    val configurationFilePath = Paths.get(getClass.getClassLoader.getResource("ingestion.properties").toURI).toString
     val args = Array(configurationFilePath)
 
     val config = PropertiesIngestionDriver.loadConfiguration(args)

--- a/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/reader/kafka/TestKafkaStreamReader.scala
+++ b/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/reader/kafka/TestKafkaStreamReader.scala
@@ -25,6 +25,7 @@ import org.scalatest.{BeforeAndAfterEach, FlatSpec}
 import za.co.absa.commons.io.TempDirectory
 import za.co.absa.hyperdrive.ingestor.implementation.reader.kafka.KafkaStreamReaderProps._
 
+import java.net.URI
 import java.nio.file.{Files, Paths}
 
 class TestKafkaStreamReader extends FlatSpec with BeforeAndAfterEach with MockitoSugar {
@@ -39,12 +40,14 @@ class TestKafkaStreamReader extends FlatSpec with BeforeAndAfterEach with Mockit
     "failOnDataLoss"          -> "false")
   private var tempDir: TempDirectory = _
   private var tempDirPath: String = _
+  private var tempDirURI: String = _
 
   behavior of "KafkaStreamReader"
 
   override def beforeEach: Unit = {
     tempDir = TempDirectory()
     tempDirPath = tempDir.path.toAbsolutePath.toString
+    tempDirURI = tempDir.path.toAbsolutePath.toUri.toString
   }
 
   override def afterEach: Unit = tempDir.delete()
@@ -62,7 +65,7 @@ class TestKafkaStreamReader extends FlatSpec with BeforeAndAfterEach with Mockit
   }
 
   it should "throw if SparkSession is stopped" in {
-    val reader = new KafkaStreamReader(validTopic, validBrokers, tempDirPath, validExtraConfs)
+    val reader = new KafkaStreamReader(validTopic, validBrokers, tempDirURI, validExtraConfs)
     val sparkContext = getMockedSparkContext(stopped = true)
     val dataStreamReader = getMockedDataStreamReader
     val sparkSession = getConfiguredMockedSparkSession(sparkContext, dataStreamReader)
@@ -74,7 +77,7 @@ class TestKafkaStreamReader extends FlatSpec with BeforeAndAfterEach with Mockit
     val dataStreamReader = getMockedDataStreamReader
     val sparkSession = getConfiguredMockedSparkSession(sparkContext, dataStreamReader)
 
-    val reader = new KafkaStreamReader(validTopic, validBrokers, tempDirPath, validExtraConfs)
+    val reader = new KafkaStreamReader(validTopic, validBrokers, tempDirURI, validExtraConfs)
     reader.read(sparkSession)
 
     verify(sparkSession).readStream
@@ -89,7 +92,7 @@ class TestKafkaStreamReader extends FlatSpec with BeforeAndAfterEach with Mockit
     val dataStreamReader = getMockedDataStreamReader
     val sparkSession = getConfiguredMockedSparkSession(sparkContext, dataStreamReader)
 
-    val reader = new KafkaStreamReader(validTopic, validBrokers, tempDirPath, Map[String,String]())
+    val reader = new KafkaStreamReader(validTopic, validBrokers, tempDirURI, Map[String,String]())
     reader.read(sparkSession)
 
     verify(sparkSession).readStream
@@ -117,7 +120,7 @@ class TestKafkaStreamReader extends FlatSpec with BeforeAndAfterEach with Mockit
     val sparkSession = getConfiguredMockedSparkSession(sparkContext, dataStreamReader)
     Files.createDirectories(Paths.get(s"$tempDirPath/empty1/empty2/empty3"))
 
-    val reader = new KafkaStreamReader(validTopic, validBrokers, tempDirPath, Map())
+    val reader = new KafkaStreamReader(validTopic, validBrokers, tempDirURI, Map())
     reader.read(sparkSession)
 
     verify(dataStreamReader).option(WORD_STARTING_OFFSETS, STARTING_OFFSETS_EARLIEST)
@@ -129,7 +132,7 @@ class TestKafkaStreamReader extends FlatSpec with BeforeAndAfterEach with Mockit
     val sparkSession = getConfiguredMockedSparkSession(sparkContext, dataStreamReader)
     Files.createFile(Paths.get(s"$tempDirPath/anyFile"))
 
-    val reader = new KafkaStreamReader(validTopic, validBrokers, tempDirPath, Map())
+    val reader = new KafkaStreamReader(validTopic, validBrokers, tempDirURI, Map())
     reader.read(sparkSession)
 
     verify(dataStreamReader, never()).option(WORD_STARTING_OFFSETS, STARTING_OFFSETS_EARLIEST)

--- a/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/utils/TestMetadataLogUtil.scala
+++ b/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/utils/TestMetadataLogUtil.scala
@@ -33,7 +33,7 @@ class TestMetadataLogUtil extends FlatSpec with Matchers with SparkTestBase with
 
   before {
     baseDir = TempDirectory("TestMetadataLogUtil").deleteOnExit()
-    baseDirPath = baseDir.path.toAbsolutePath.toString
+    baseDirPath = baseDir.path.toAbsolutePath.toUri.toString
   }
 
   after {
@@ -73,7 +73,7 @@ class TestMetadataLogUtil extends FlatSpec with Matchers with SparkTestBase with
 
   it should "return the empty set if the root folder is empty" in {
     val dir = TempDirectory()
-    val diff = MetadataLogUtil.getParquetFilesNotListedInMetadataLog(spark, dir.path.toAbsolutePath.toString)
+    val diff = MetadataLogUtil.getParquetFilesNotListedInMetadataLog(spark, dir.path.toAbsolutePath.toUri.toString)
 
     diff.isSuccess shouldBe true
     diff.get shouldBe empty

--- a/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/TestParquetStreamWriter.scala
+++ b/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/parquet/TestParquetStreamWriter.scala
@@ -94,7 +94,7 @@ class TestParquetStreamWriter extends FlatSpec with MockitoSugar with Matchers w
   it should "throw an exception if the metadata log is inconsistent" in {
     import spark.implicits._
     val baseDir = TempDirectory("TestParquetStreamWriter").deleteOnExit()
-    val destinationPath = s"${baseDir.path.toAbsolutePath.toString}/destination"
+    val destinationPath = s"${baseDir.path.toAbsolutePath.toUri.toString}/destination"
     val input = MemoryStream[Int](1, spark.sqlContext)
     input.addData(List.range(0, 100))
     val df = input.toDF()


### PR DESCRIPTION
Fixed all failing unit tests:

Module "ingestor-default_2.12" - 9 Tests Failed
- return empty set if no partial writes have occurred
- return the empty set if the root folder is empty
- return the filenames that are missing in the metadata log
- throw if SparkSession is stopped
- set topic, brokers and options on SparkSession
- set topic and brokers on SparkSession if no extra options informed
- set offsets to earliest if checkpoint location is empty
- not set offsets to earliest if a checkpoint location exists and is not empty
- throw an exception if the metadata log is inconsistent

Module "driver_2.12" - 1 Tests Failed
- load all configuration

Closes #286 