### PR TITLE
Add profile to run tests on m1

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ git clone git@github.com:AbsaOSS/hyperdrive.git
 mvn clean package
 ```
 
+For Apple M1 users
+```bash
+mvn clean package -Pspark-3,scala-2.12,m1
+```
+
+
 Given a configuration file has already been created, hyperdrive can be executed as follows:
 ```
 spark-submit --class za.co.absa.hyperdrive.driver.drivers.PropertiesIngestionDriver driver/target/driver*.jar config.properties

--- a/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/testutils/mongodb/MongoDbFixture.scala
+++ b/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/testutils/mongodb/MongoDbFixture.scala
@@ -22,14 +22,9 @@ trait MongoDbFixture extends BeforeAndAfterAll {
 
   this: Suite =>
 
-  // Workaround to fix version not supported error
-  if (System.getProperty("os.arch") == "aarch64" && System.getProperty("os.name") == "Mac OS X") {
-    System.setProperty("os.arch", "i686_64")
-  }
-
   import ScalaMongoImplicits._
 
-  private val (mongoDbExecutable, mongoPort) = EmbeddedMongoDbSingleton.embeddedMongoDb
+  private lazy val (mongoDbExecutable, mongoPort) = EmbeddedMongoDbSingleton.embeddedMongoDb
 
   def uri: String = s"mongodb://localhost:$mongoPort"
 

--- a/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/mongodb/MongoDbTest.scala
+++ b/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/mongodb/MongoDbTest.scala
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package za.co.absa.hyperdrive.ingestor.implementation.writer.mongodb
 

--- a/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/mongodb/MongoDbTest.scala
+++ b/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/mongodb/MongoDbTest.scala
@@ -1,0 +1,6 @@
+
+package za.co.absa.hyperdrive.ingestor.implementation.writer.mongodb
+
+import org.scalatest.Tag
+
+object MongoDbTest extends Tag("za.co.absa.hyperdrive.ingestor.implementation.testutils.mongodb.MongoDbTest")

--- a/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/mongodb/TestMongoDbStreamWriterIntegration.scala
+++ b/ingestor-default/src/test/scala/za/co/absa/hyperdrive/ingestor/implementation/writer/mongodb/TestMongoDbStreamWriterIntegration.scala
@@ -39,7 +39,7 @@ class TestMongoDbStreamWriterIntegration extends FlatSpec with SparkTestBase wit
     clearDb()
   }
 
-  it should "write data to MongoDB" in {
+  it should "write data to MongoDB" taggedAs (MongoDbTest) in {
     // given
     val inputData = Range(0, 100).toDF
 
@@ -57,7 +57,7 @@ class TestMongoDbStreamWriterIntegration extends FlatSpec with SparkTestBase wit
     }
   }
 
-  it should "support checkpoints" in {
+  it should "support checkpoints" taggedAs (MongoDbTest) in {
     // given
     val inputData1 = Range(0, 100).toDF
     val inputData2 = Range(0, 150).toDF
@@ -87,7 +87,7 @@ class TestMongoDbStreamWriterIntegration extends FlatSpec with SparkTestBase wit
 
   }
 
-  it should "write structured data to MongoDB" in {
+  it should "write structured data to MongoDB" taggedAs (MongoDbTest) in {
     // given
     val inputData = Seq(
       ("John Doe", 48, 181.5, BigDecimal(10500.22), List(1, 10, 100)),

--- a/parent-conf/pom.xml
+++ b/parent-conf/pom.xml
@@ -76,6 +76,7 @@
         <buildnumber.maven.version>1.4</buildnumber.maven.version>
 
         <!--Other properties-->
+        <skip.mongodb.tests>false</skip.mongodb.tests>
         <skip.docker.tests>true</skip.docker.tests>
         <jacoco.plugin.version>0.8.8</jacoco.plugin.version>
     </properties>
@@ -324,6 +325,18 @@
                         </goals>
                         <configuration>
                             <suffixes>(?&lt;!DockerTest)</suffixes>
+                            <tagsToExclude>za.co.absa.hyperdrive.ingestor.implementation.testutils.mongodb.MongoDbTest</tagsToExclude>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>mongo-db-tests</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <suffixes>(?&lt;!DockerTest)</suffixes>
+                            <tagsToInclude>za.co.absa.hyperdrive.ingestor.implementation.testutils.mongodb.MongoDbTest</tagsToInclude>
+                            <skipTests>${skip.mongodb.tests}</skipTests>
                         </configuration>
                     </execution>
                     <execution>
@@ -385,6 +398,12 @@
             <id>all-tests</id>
             <properties>
                 <skip.docker.tests>false</skip.docker.tests>
+            </properties>
+        </profile>
+        <profile>
+            <id>m1</id>
+            <properties>
+                <skip.mongodb.tests>true</skip.mongodb.tests>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
Currently, tests are failing on the Mac M1 even with the `spark-3` and `scala-2.12` profiles enabled. This is because of a workaround that was introduced for the MongoDb tests in #279. To make the tests run on M1, a profile was introduced that excludes the MongoDbTests from being run.

Tests can be executed on M1 using these profiles:

`mvn clean test -Pspark-3,scala-2.12,m1`

This PR merely introduces a switch to ignore the failing tests. The issue should be resolved in #277 

Signed-off-by: Kevin Wallimann <kevin.wallimann@absa.africa>